### PR TITLE
Fix DualGauge rendering, add manual G‑Meter calibration persistence, and improve 0-60 AccelerationMeter

### DIFF
--- a/ESP32OBDGauge.ino
+++ b/ESP32OBDGauge.ino
@@ -20,7 +20,9 @@ uint32_t outlineColor = GAUGE_FG_COLOR;
 uint32_t needleColor = NEEDLE_COLOR_PRIMARY;
 uint32_t valueColor = VALUE_TEXT_COLOR;
 int currentGauge = 0;
-float mpuCalibrationMatrix[3][3]; // 3x3 rotation matrix obtained when statically calibrating the MPU-6050
+float mpuCalibrationMatrix[3][3]; // Persisted G-meter rotation matrix
+Vec3 mpuCalibrationBias = {0.0f, 0.0f, 0.0f};
+bool gmeterCalibrationStored = false;
 
 Preferences preferences;
 TFT_eSPI display = TFT_eSPI();
@@ -71,6 +73,10 @@ void setup() {
     gauges[5] = new GMeter(&display);
     gauges[6] = new AccelerationMeter(&display);
 
+    if (gmeterCalibrationStored) {
+        static_cast<GMeter*>(gauges[5])->setStoredCalibration(mpuCalibrationMatrix, mpuCalibrationBias);
+    }
+
     if (!obdConnected) {
         currentGauge = FALLBACK_GAUGE_INDEX;
     }
@@ -90,6 +96,17 @@ void readSettings() {
     needleColor = preferences.getUInt("needleColor", NEEDLE_COLOR_PRIMARY);
     valueColor = preferences.getUInt("valueColor", VALUE_TEXT_COLOR);
     currentGauge = preferences.getInt("currentGauge", 0);
+
+    gmeterCalibrationStored = preferences.getBool("gmCalSaved", false);
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            String key = "gmr" + String(i) + String(j);
+            mpuCalibrationMatrix[i][j] = preferences.getFloat(key.c_str(), (i == j) ? 1.0f : 0.0f);
+        }
+    }
+    mpuCalibrationBias.x = preferences.getFloat("gmbx", 0.0f);
+    mpuCalibrationBias.y = preferences.getFloat("gmby", 0.0f);
+    mpuCalibrationBias.z = preferences.getFloat("gmbz", 0.0f);
 
     // Close preferences
     preferences.end();
@@ -120,6 +137,24 @@ void updateCurrentGaugeColorSettings(uint32_t currNeedleColor, uint32_t currOutl
     // Close preferences
     preferences.end();
     return;
+}
+
+
+void updateGMeterCalibrationSettings(const float rotation[3][3], const Vec3& bias) {
+    preferences.begin("OBDGAUGE", false);
+
+    preferences.putBool("gmCalSaved", true);
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            String key = "gmr" + String(i) + String(j);
+            preferences.putFloat(key.c_str(), rotation[i][j]);
+        }
+    }
+    preferences.putFloat("gmbx", bias.x);
+    preferences.putFloat("gmby", bias.y);
+    preferences.putFloat("gmbz", bias.z);
+
+    preferences.end();
 }
 
 void dataFetchingTask(void* parameter) {
@@ -263,6 +298,21 @@ void loop() {
         if (current != nullptr) {
             current->render(0.0);
         }
+
+        GMeter* gm = static_cast<GMeter*>(gauges[5]);
+        float savedRotation[3][3];
+        Vec3 savedBias;
+        if (gm->consumeCalibration(savedRotation, savedBias)) {
+            updateGMeterCalibrationSettings(savedRotation, savedBias);
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < 3; j++) {
+                    mpuCalibrationMatrix[i][j] = savedRotation[i][j];
+                }
+            }
+            mpuCalibrationBias = savedBias;
+            gmeterCalibrationStored = true;
+        }
+
         xSemaphoreGive(gaugeMutex);
         //if (obdConnected) {
             //display.drawRect(0, 0, 10, 10, TFT_GREEN);

--- a/acceleration_meter.h
+++ b/acceleration_meter.h
@@ -12,34 +12,23 @@ public:
         speed(display),
         speedLabel(display),
         message(display),
-        startValue(0.00),
-        endValue(60.00),
-        timeValue(0.00),
-        latestSpeed(0.00),
-        endSpeedReached(false),
-        previousSpeed(0.00),
-        startTime(0),
-        previousTime(0),
-        timerStarted(false) {}
+        latestSpeed(0.0),
+        displayedSpeed(-1),
+        previousSpeed(0.0),
+        runTimeSeconds(0.0),
+        stationaryStartMs(0),
+        startTimeUs(0),
+        previousTimeUs(0),
+        stage(WAIT_STATIONARY) {}
 
     void initialize() override {
         display->fillScreen(DISPLAY_BG_COLOR);
-        int textWidth = 0;
-        int textHeight = 0;
 
         speed.setColorDepth(8);
         speed.setTextSize(7);
         speed.setTextFont(1);
-        speed.setTextColor(TFT_RED);
-        textWidth = speed.textWidth("77");
-        textHeight = speed.fontHeight();
-        speed.createSprite(textWidth, textHeight);
-        textWidth = speed.textWidth("0");
-        textHeight = speed.fontHeight();
-        Serial.printf("SPEED\ntextWidth: %.1d\ntextHeight: %.1d\nspriteWidth: %.1d\nspriteHeight: %.1d\n", textWidth, textHeight, speed.width(), speed.height());
-        speed.setCursor((speed.width() - textWidth) / 2, (speed.height() - textHeight) / 2);
-        speed.println("0");
-        speed.pushSprite((DISPLAY_WIDTH - speed.width()) / 2, 60);
+        speed.setTextColor(TFT_RED, DISPLAY_BG_COLOR);
+        speed.createSprite(speed.textWidth("188"), speed.fontHeight());
 
         speedLabel.setColorDepth(1);
         speedLabel.setTextFont(1);
@@ -48,21 +37,12 @@ public:
         speedLabel.createSprite(speedLabel.textWidth(AMETER_SPEED_LABEL), speedLabel.fontHeight());
         speedLabel.setCursor(0, 0);
         speedLabel.println(AMETER_SPEED_LABEL);
-        speedLabel.pushSprite((DISPLAY_WIDTH - speedLabel.width()) / 2, 60 - speedLabel.height() - AMETER_V_PADDING);
 
         time.setColorDepth(8);
         time.setTextSize(5);
         time.setTextFont(1);
-        time.setTextColor(TFT_RED);
-        textWidth = time.textWidth("77.77");
-        textHeight = time.fontHeight();
-        time.createSprite(textWidth, textHeight);
-        textWidth = time.textWidth("0.00");
-        textHeight = time.fontHeight();
-        Serial.printf("TIME\ntextWidth: %.1d\ntextHeight: %.1d\nspriteWidth: %.1d\nspriteHeight: %.1d\n", textWidth, textHeight, time.width(), time.height());
-        time.setCursor((time.width() - textWidth) / 2, (time.height() - textHeight) / 2);
-        time.println("0.00");
-        time.pushSprite((DISPLAY_WIDTH - time.width()) / 2, 175);
+        time.setTextColor(AMETER_TIME_COLOR, DISPLAY_BG_COLOR);
+        time.createSprite(time.textWidth("00.000"), time.fontHeight());
 
         timeLabel.setColorDepth(1);
         timeLabel.setTextFont(1);
@@ -71,15 +51,80 @@ public:
         timeLabel.createSprite(timeLabel.textWidth(AMETER_TIME_LABEL), timeLabel.fontHeight());
         timeLabel.setCursor(0, 0);
         timeLabel.println(AMETER_TIME_LABEL);
+
+        message.setColorDepth(8);
+        message.setTextFont(2);
+        message.setTextSize(1);
+        message.setTextColor(TFT_YELLOW, DISPLAY_BG_COLOR);
+        message.createSprite(DISPLAY_WIDTH, 20);
+
+        speedLabel.pushSprite((DISPLAY_WIDTH - speedLabel.width()) / 2, 60 - speedLabel.height() - AMETER_V_PADDING);
         timeLabel.pushSprite((DISPLAY_WIDTH - timeLabel.width()) / 2, 175 - timeLabel.height() - AMETER_V_PADDING);
+
+        drawSpeed((int)round(latestSpeed));
+        drawTime(runTimeSeconds, stage == FINISHED ? TFT_GREEN : AMETER_TIME_COLOR);
+        drawMessageForStage();
     }
 
-    void setSpeed(double speed) {
-        latestSpeed = speed;
+    void setSpeed(double speedVal) {
+        latestSpeed = speedVal;
     }
 
     void render(double) override {
-        renderAccelerationMeter(latestSpeed);
+        unsigned long nowMs = millis();
+        unsigned long long nowUs = micros();
+
+        drawSpeed((int)round(latestSpeed));
+
+        switch (stage) {
+            case WAIT_STATIONARY:
+                if (latestSpeed <= 1.0) {
+                    if (stationaryStartMs == 0) {
+                        stationaryStartMs = nowMs;
+                    }
+                    if (nowMs - stationaryStartMs >= 3000) {
+                        stage = READY;
+                        runTimeSeconds = 0.0;
+                        drawTime(runTimeSeconds, AMETER_TIME_COLOR);
+                        drawMessageForStage();
+                    }
+                } else {
+                    stationaryStartMs = 0;
+                }
+                break;
+
+            case READY:
+                if (latestSpeed > 1.5) {
+                    stage = RUNNING;
+                    startTimeUs = nowUs;
+                    previousTimeUs = nowUs;
+                    previousSpeed = latestSpeed;
+                    drawMessageForStage();
+                }
+                break;
+
+            case RUNNING:
+                runTimeSeconds = (double)(nowUs - startTimeUs) / 1000000.0;
+
+                if (previousSpeed < 60.0 && latestSpeed >= 60.0 && latestSpeed > previousSpeed) {
+                    double fraction = (60.0 - previousSpeed) / (latestSpeed - previousSpeed);
+                    unsigned long long crossedUs = previousTimeUs + (unsigned long long)(fraction * (double)(nowUs - previousTimeUs));
+                    runTimeSeconds = (double)(crossedUs - startTimeUs) / 1000000.0;
+                    stage = FINISHED;
+                    drawTime(runTimeSeconds, TFT_GREEN);
+                    drawMessageForStage();
+                } else {
+                    drawTime(runTimeSeconds, AMETER_TIME_COLOR);
+                }
+
+                previousSpeed = latestSpeed;
+                previousTimeUs = nowUs;
+                break;
+
+            case FINISHED:
+                // Latch final run time until reset() is called by user.
+                break;
+        }
     }
 
     void displayStats(float fps, double frameAvg, double queryAvg) override {
@@ -93,88 +138,86 @@ public:
         return ACCELERATION_METER;
     }
 
-    uint32_t getCurrentNeedleColor() {
-        return 0;
+    void reset() override {
+        stage = WAIT_STATIONARY;
+        stationaryStartMs = 0;
+        startTimeUs = 0;
+        previousTimeUs = 0;
+        previousSpeed = latestSpeed;
+        runTimeSeconds = 0.0;
+        displayedSpeed = -1;
+        initialize();
     }
 
-    uint32_t getCurrentOutlineColor() {
-        return 0;
-    }
-
-    uint32_t getCurrentValueColor() {
-        return 0;
-    }
+    uint32_t getCurrentNeedleColor() { return 0; }
+    uint32_t getCurrentOutlineColor() { return 0; }
+    uint32_t getCurrentValueColor() { return 0; }
 
 private:
+    enum MeterStage { WAIT_STATIONARY, READY, RUNNING, FINISHED };
+
     TFT_eSprite time, speed, timeLabel, speedLabel, message;
-    double timeValue, startValue, endValue, latestSpeed, previousSpeed;
-    unsigned long startTime, previousTime;
-    bool endSpeedReached, timerStarted;
+    double latestSpeed;
+    int displayedSpeed;
+    double previousSpeed;
+    double runTimeSeconds;
+    unsigned long stationaryStartMs;
+    unsigned long long startTimeUs;
+    unsigned long long previousTimeUs;
+    MeterStage stage;
 
-    void renderAccelerationMeter(double speedVal) {
-        unsigned int now = millis();
-
-        if (!timerStarted && previousSpeed == 0.0 && speedVal >= 1.0) {
-            startTime = now;
-            timerStarted = true;
-        }
-
-        if (endSpeedReached) {
+    void drawSpeed(int speedInt) {
+        if (speedInt == displayedSpeed) {
             return;
         }
 
-        if (timerStarted && previousSpeed < 60.0 && speedVal >= 60.0) {
-            double fraction = (60.0 - previousSpeed) / (speedVal - previousSpeed);
-            unsigned long interpolatedTime = previousTime + fraction * (now - previousTime);
-            unsigned int elapsedMilliseconds = interpolatedTime - startTime;
-            int seconds = elapsedMilliseconds / 1000;
-            int milliseconds = elapsedMilliseconds % 1000;
-            char timeStr[8];
-            sprintf(timeStr, "%d.%03d", seconds, milliseconds);
-            String currentTime = String(timeStr);
-            time.fillSprite(DISPLAY_BG_COLOR);
-            time.setTextColor(TFT_GREEN);
-            int textWidth = time.textWidth(currentTime);
-            int textHeight = time.fontHeight();
-            time.setCursor((time.width() - textWidth) / 2, (time.height() - textHeight) / 2);
-            time.println(currentTime);
-            time.pushSprite((DISPLAY_WIDTH - time.width()) / 2, 175);
-            endSpeedReached = true;
-        } else if (timerStarted) {
-            unsigned int elapsedMilliseconds = now - startTime;
-            int seconds = elapsedMilliseconds / 1000;
-            int milliseconds = elapsedMilliseconds % 1000;
-            char timeStr[8];
-            sprintf(timeStr, "%d.%03d", seconds, milliseconds);
-            String currentTime = String(timeStr);
-            int textWidth = time.textWidth(currentTime);
-            int textHeight = time.fontHeight();
-            time.fillSprite(DISPLAY_BG_COLOR);
-            time.setCursor((time.width() - textWidth) / 2, (time.height() - textHeight) / 2);
-            time.println(currentTime);
-            time.pushSprite((DISPLAY_WIDTH - time.width()) / 2, 175);
-        }
-
-        String text = String((int)speedVal);
+        String text = String(speedInt);
+        speed.fillSprite(DISPLAY_BG_COLOR);
         int textWidth = speed.textWidth(text);
         int textHeight = speed.fontHeight();
-        speed.fillSprite(DISPLAY_BG_COLOR);
         speed.setCursor((speed.width() - textWidth) / 2, (speed.height() - textHeight) / 2);
         speed.println(text);
         speed.pushSprite((DISPLAY_WIDTH - speed.width()) / 2, 60);
-
-        previousSpeed = speedVal;
-        previousTime = now;
+        displayedSpeed = speedInt;
     }
 
-    void reset() {
-        previousSpeed = 0.0;
-        previousTime = 0;
-        timerStarted = false;
-        endSpeedReached = false;
-        startTime = 0;
-        time.setTextColor(TFT_RED);
-        render(0.0);
+    void drawTime(double seconds, uint16_t color) {
+        char timeStr[16];
+        snprintf(timeStr, sizeof(timeStr), "%0.3f", seconds);
+        String text(timeStr);
+
+        time.fillSprite(DISPLAY_BG_COLOR);
+        time.setTextColor(color, DISPLAY_BG_COLOR);
+        int textWidth = time.textWidth(text);
+        int textHeight = time.fontHeight();
+        time.setCursor((time.width() - textWidth) / 2, (time.height() - textHeight) / 2);
+        time.println(text);
+        time.pushSprite((DISPLAY_WIDTH - time.width()) / 2, 175);
+    }
+
+    void drawMessageForStage() {
+        const char* text = "";
+        uint16_t color = TFT_YELLOW;
+
+        if (stage == WAIT_STATIONARY) {
+            text = "Keep vehicle still for 3s to arm";
+        } else if (stage == READY) {
+            text = "Ready - accelerate to start";
+            color = TFT_CYAN;
+        } else if (stage == RUNNING) {
+            text = "Measuring 0-60...";
+            color = TFT_ORANGE;
+        } else if (stage == FINISHED) {
+            text = "Done - tap reset button";
+            color = TFT_GREEN;
+        }
+
+        message.fillSprite(DISPLAY_BG_COLOR);
+        message.setTextColor(color, DISPLAY_BG_COLOR);
+        int textWidth = message.textWidth(text);
+        message.setCursor((DISPLAY_WIDTH - textWidth) / 2, 4);
+        message.println(text);
+        message.pushSprite(0, DISPLAY_HEIGHT - message.height());
     }
 };
 

--- a/dual_gauge.h
+++ b/dual_gauge.h
@@ -150,7 +150,7 @@ private:
         Serial.println("Failed to create gaugeOutlineLeft sprite");
       }
 
-      if (!gaugeOutlineRight.createSprite(DG_BAR_WIDTH, DG_BAR_WIDTH)) {
+      if (!gaugeOutlineRight.createSprite(DG_BAR_WIDTH, DG_BAR_HEIGHT)) {
         Serial.println("Failed to create gaugeOutlineRight sprite");
       }
 
@@ -176,6 +176,9 @@ private:
       gaugeOutlineRight.fillRect(1, 1, DG_BAR_WIDTH - 2, DG_BAR_HEIGHT - 2, needleColor);
 
       // Fill bar from top down with black to (1 - (value / maxValue)) * DG_BAR_HEIGHT
+      leftVal = constrain(leftVal, minValueLeft, maxValueLeft);
+      rightVal = constrain(rightVal, minValueRight, maxValueRight);
+
       int y = (1 - (leftVal / maxValueLeft)) * DG_BAR_HEIGHT;
       if (y != 0) {
         // Only render black if bar graph is not full
@@ -194,7 +197,7 @@ private:
       gaugeOutlineLeft.pushSprite(xPos, yPos);
 
       xPos = 3 * (DISPLAY_WIDTH / 4) - (DG_BAR_WIDTH / 2);
-      gaugeOutlineLeft.pushSprite(xPos, yPos);
+      gaugeOutlineRight.pushSprite(xPos, yPos);
     }
 
     void createLabels() {
@@ -299,7 +302,6 @@ String DualGauge::gaugeTypes[2][5] = {
 };
 
 #endif
-
 
 
 

--- a/g_meter.h
+++ b/g_meter.h
@@ -21,7 +21,11 @@ public:
         maxValueX(0.0),
         maxValueY(0.0),
         oldX(0),
-        oldY(0) {}
+        oldY(0),
+        filteredX(0.0),
+        filteredY(0.0),
+        hasFilter(false),
+        calibrationDirty(false) {}
 
     void initialize() override {
         display->fillScreen(DISPLAY_BG_COLOR);
@@ -57,7 +61,6 @@ public:
         mpu.setAccelerometerRange(MPU6050_RANGE_2_G);
         mpu.setFilterBandwidth(MPU6050_BAND_5_HZ);
 
-        calibration.startCalibration();
         oldX = gaugeCenterX - GMETER_POINT_RADIUS;
         oldY = gaugeCenterY - GMETER_POINT_RADIUS;
     }
@@ -67,6 +70,10 @@ public:
         latestGyro = *gyro;
         latestTemp = *temp;
         calibration.addSample(latestAccel);
+        if (!calibration.isCollecting() && calibration.isCalibrated() && calibrationInProgress) {
+            calibrationInProgress = false;
+            calibrationDirty = true;
+        }
     }
 
     void render(double) override {
@@ -74,7 +81,8 @@ public:
             display->setTextColor(TFT_YELLOW, DISPLAY_BG_COLOR);
             display->setTextSize(1);
             display->setCursor(5, 5);
-            display->print("Calibrating GMeter...");
+            int pct = (calibration.getSampleCount() * 100) / calibration.getRequiredSamples();
+            display->printf("Calibrating GMeter... %d%%   ", pct);
             return;
         }
 
@@ -82,14 +90,39 @@ public:
         double gForceX = normalized.y;
         double gForceY = normalized.x;
 
-        if (gForceX < -3 || gForceX > 3 || gForceY < -3 || gForceY > 3) {
+        if (!isfinite(gForceX) || !isfinite(gForceY)) {
             return;
         }
 
+        // Reject impossible spikes and smooth incoming data to avoid outlier history points.
+        if (fabs(gForceX) > 3.0 || fabs(gForceY) > 3.0) {
+            return;
+        }
+
+        if (!hasFilter) {
+            filteredX = gForceX;
+            filteredY = gForceY;
+            hasFilter = true;
+        }
+
+        double dx = gForceX - filteredX;
+        double dy = gForceY - filteredY;
+        const double spikeLimit = 0.45;
+        if (fabs(dx) > spikeLimit || fabs(dy) > spikeLimit) {
+            return;
+        }
+
+        const double alpha = 0.25;
+        filteredX = filteredX + alpha * dx;
+        filteredY = filteredY + alpha * dy;
+
+        if (fabs(filteredX) < 0.02) filteredX = 0.0;
+        if (fabs(filteredY) < 0.02) filteredY = 0.0;
+
         int gaugeCenterX = DISPLAY_CENTER_X;
         int gaugeCenterY = DISPLAY_CENTER_Y;
-        int posX = gaugeCenterX - (GMETER_RADIUS * gForceX / 2);
-        int posY = gaugeCenterY - (GMETER_RADIUS * gForceY / 2);
+        int posX = gaugeCenterX - (GMETER_RADIUS * filteredX / 2);
+        int posY = gaugeCenterY - (GMETER_RADIUS * filteredY / 2);
 
         if (abs(posX - oldX) > 1 || abs(posY - oldY) > 1) {
             drawOutline();
@@ -101,7 +134,29 @@ public:
             oldY = posY;
         }
 
-        updateMinMaxValues(gForceX, gForceY);
+        updateMinMaxValues(filteredX, filteredY);
+    }
+
+    void beginManualCalibration() {
+        calibration.startCalibration();
+        calibrationInProgress = true;
+        calibrationDirty = false;
+        hasFilter = false;
+    }
+
+    bool consumeCalibration(float outRotation[3][3], Vec3& outBias) {
+        if (!calibrationDirty) {
+            return false;
+        }
+        calibration.getCalibration(outRotation, outBias);
+        calibrationDirty = false;
+        return true;
+    }
+
+    void setStoredCalibration(const float inRotation[3][3], const Vec3& inBias) {
+        calibration.setCalibration(inRotation, inBias);
+        calibrationInProgress = false;
+        calibrationDirty = false;
     }
 
     void reset() {
@@ -109,7 +164,7 @@ public:
         minValueY = 0.0;
         maxValueX = 0.0;
         maxValueY = 0.0;
-        calibration.startCalibration();
+        hasFilter = false;
         history.fillSprite(TFT_TRANSPARENT);
         updateTextSprite(maxX, "0.00");
         updateTextSprite(minX, "0.00");
@@ -135,6 +190,10 @@ private:
     sensors_event_t latestAccel, latestGyro, latestTemp;
     double minValueX, maxValueX, minValueY, maxValueY;
     int oldX, oldY;
+    double filteredX, filteredY;
+    bool hasFilter;
+    bool calibrationInProgress = false;
+    bool calibrationDirty;
     GMeterCalibration calibration;
 
     void drawOutline() {

--- a/gmeter_calibration.h
+++ b/gmeter_calibration.h
@@ -47,6 +47,8 @@ public:
 
     bool isCollecting() const { return collecting; }
     bool isCalibrated() const { return calibrated; }
+    int getSampleCount() const { return sampleCount; }
+    int getRequiredSamples() const { return REQUIRED_SAMPLES; }
 
     Vec3 normalize(const sensors_event_t& accel) const {
         Vec3 raw = {
@@ -58,11 +60,33 @@ public:
         Vec3 rotated = multiply(rotation, raw);
         rotated.x -= bias.x;
         rotated.y -= bias.y;
+        rotated.z -= bias.z;
         return rotated;
     }
 
+    void getCalibration(float outRotation[3][3], Vec3& outBias) const {
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                outRotation[i][j] = rotation[i][j];
+            }
+        }
+        outBias = bias;
+    }
+
+    void setCalibration(const float inRotation[3][3], const Vec3& inBias) {
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                rotation[i][j] = inRotation[i][j];
+            }
+        }
+        bias = inBias;
+        calibrated = true;
+        collecting = false;
+        sampleCount = 0;
+    }
+
 private:
-    static const int REQUIRED_SAMPLES = 200;
+    static const int REQUIRED_SAMPLES = 250;
     bool calibrated;
     bool collecting;
     int sampleCount;
@@ -100,7 +124,7 @@ private:
         return {v.x / n, v.y / n, v.z / n};
     }
 
-    static Vec3 multiply(float m[3][3], const Vec3& v) {
+    static Vec3 multiply(const float m[3][3], const Vec3& v) {
         return {
             m[0][0] * v.x + m[0][1] * v.y + m[0][2] * v.z,
             m[1][0] * v.x + m[1][1] * v.y + m[1][2] * v.z,

--- a/options_screen.h
+++ b/options_screen.h
@@ -32,7 +32,7 @@ public:
                     int bx = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
                     int by = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
                     if (x >= bx && x < bx + BUTTON_WIDTH && y >= by && y < by + BUTTON_HEIGHT) {
-                        if (i == 0 && j == 0) { // Gauge settings
+                        if (i == 0 && j == 0) { // G-meter calibration
                             state = ABOUT;
                             drawAboutMenu();
                             return true;
@@ -89,9 +89,25 @@ private:
     };
 
     bool handleAboutTouch(uint16_t x, uint16_t y) {
-        // Exit about screen on any touch
-        state = MAIN_MENU;
-        drawMainMenu();
+        int buttonWidth = 190;
+        int buttonHeight = 55;
+        int calibrateX = (DISPLAY_WIDTH - buttonWidth) / 2;
+        int calibrateY = 90;
+        int backX = calibrateX;
+        int backY = 160;
+
+        if (x >= calibrateX && x < calibrateX + buttonWidth && y >= calibrateY && y < calibrateY + buttonHeight) {
+            triggerGMeterCalibration();
+            drawAboutMenu();
+            return true;
+        }
+
+        if (x >= backX && x < backX + buttonWidth && y >= backY && y < backY + buttonHeight) {
+            state = MAIN_MENU;
+            drawMainMenu();
+            return true;
+        }
+
         return true;
     }
 
@@ -191,7 +207,7 @@ private:
 
         // Draw 2x2 grid of buttons
         const char* labels[2][2] = {
-            {"About", "Bluetooth"},
+            {"G-Meter", "Bluetooth"},
             {"Color", "Exit"}
         };
         for (int i = 0; i < 2; i++) {
@@ -215,24 +231,38 @@ private:
         screenSprite.setTextSize(2);
         screenSprite.setTextColor(TFT_WHITE);
 
-        String title = "About";
+        String title = "G-Meter Calibration";
         int titleWidth = screenSprite.textWidth(title);
         int x = DISPLAY_CENTER_X - (titleWidth / 2);
-        screenSprite.setCursor(x, 30);
+        screenSprite.setCursor(x, 24);
         screenSprite.print(title);
 
         screenSprite.setTextSize(1);
-        String version = "Version: " + String(SOFTWARE_VERSION);
-        int versionWidth = screenSprite.textWidth(version);
-        x = DISPLAY_CENTER_X - (versionWidth / 2);
-        screenSprite.setCursor(x, 60);
-        screenSprite.print(version);
+        String text = "Park on flat ground before calibrating.";
+        int textWidth = screenSprite.textWidth(text);
+        x = DISPLAY_CENTER_X - (textWidth / 2);
+        screenSprite.setCursor(x, 55);
+        screenSprite.print(text);
 
-        String device = "Device: " + String(DEVICE_DESCRIPTION);
-        int deviceWidth = screenSprite.textWidth(device);
-        x = DISPLAY_CENTER_X - (deviceWidth / 2);
-        screenSprite.setCursor(x, 90);
-        screenSprite.print(device);
+        int buttonWidth = 190;
+        int buttonHeight = 55;
+        int buttonX = (DISPLAY_WIDTH - buttonWidth) / 2;
+
+        screenSprite.fillRect(buttonX, 90, buttonWidth, buttonHeight, TFT_DARKGREEN);
+        screenSprite.drawRect(buttonX, 90, buttonWidth, buttonHeight, TFT_WHITE);
+        String calibrate = "Start Calibration";
+        int calibrateWidth = screenSprite.textWidth(calibrate);
+        int calibrateHeight = screenSprite.fontHeight();
+        screenSprite.setCursor(buttonX + (buttonWidth - calibrateWidth) / 2, 90 + (buttonHeight - calibrateHeight) / 2);
+        screenSprite.print(calibrate);
+
+        screenSprite.fillRect(buttonX, 160, buttonWidth, buttonHeight, TFT_DARKGREY);
+        screenSprite.drawRect(buttonX, 160, buttonWidth, buttonHeight, TFT_WHITE);
+        String back = "Back";
+        int backWidth = screenSprite.textWidth(back);
+        int backHeight = screenSprite.fontHeight();
+        screenSprite.setCursor(buttonX + (buttonWidth - backWidth) / 2, 160 + (buttonHeight - backHeight) / 2);
+        screenSprite.print(back);
 
         screenSprite.pushSprite(0, 0);
     }
@@ -287,6 +317,16 @@ private:
             }
         }
         screenSprite.pushSprite(0, 0);
+    }
+
+
+    void triggerGMeterCalibration() {
+        for (int i = 0; i < numGauges; i++) {
+            if (gauges[i]->getType() == Gauge::G_METER) {
+                static_cast<GMeter*>(gauges[i])->beginManualCalibration();
+                break;
+            }
+        }
     }
 
     void drawColorPicker() {


### PR DESCRIPTION
### Motivation
- Correct DualGauge so left and right bar graphs render independently and do not mirror the same visual value. 
- Replace automatic G‑Meter auto‑calibration with a manual calibration flow the user can trigger from Options and persist the resulting rotation matrix/bias to flash. 
- Suppress spurious G‑Meter outliers when stationary and avoid logging erroneous history points. 
- Make the AccelerationMeter measure 0–60 timing reliably by arming while stationary, timing on launch, interpolating the 60 mph crossing, and latching results until reset.

### Description
- DualGauge: fixed sprite creation size and corrected sprite push targets, added clamping of input values before computing fill height so each bar renders independently (modified `dual_gauge.h`).
- GMeter calibration: moved calibration to a manual flow triggered from the Options menu (`G‑Meter` → `Start Calibration`) and added helper calls to begin/consume calibration (`options_screen.h`, `g_meter.h`).
- GMeter persistence & filtering: added `GMeterCalibration` getters/setters and saving/loading of rotation matrix + bias through `Preferences` in `ESP32OBDGauge.ino` and `gmeter_calibration.h`, and implemented runtime spike rejection + exponential smoothing to prevent outlier history points (`g_meter.h`).
- AccelerationMeter: rewrote as an explicit state machine that waits for 3s stationary to arm, starts timing on launch, interpolates the 60 mph crossing for precise timing, and latches the final time until `reset()` is called (`acceleration_meter.h`).
- Minor supportive changes: increased calibration sample count and improved calibration API (`gmeter_calibration.h`), UI additions to Options for starting calibration and handling calibration state (`options_screen.h`, `ESP32OBDGauge.ino`).

### Testing
- Ran repository scans (`rg`) and file inspections to verify modified symbols and call sites; these searches confirmed the new calibration flow and function usages (success).
- Attempted tool check with `arduino-cli version` but the command is not available in this environment (failed: `command not found`).
- Performed automated sanity checks (`nl`, `sed`, `rg`) to ensure code fragments for the new flows were inserted and references updated (success).
- No on-device or hardware-in-the-loop tests were possible here; sensor and display behavior should be validated on the target device before release.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1e80955248323b2f7663316c5e33a)