### PR TITLE
Add QuadrantGauge UI with selector and refactor Commands/OBD handling

### DIFF
--- a/ESP32OBDGauge.ino
+++ b/ESP32OBDGauge.ino
@@ -7,6 +7,7 @@
 #include "dual_gauge.h"
 #include "g_meter.h"
 #include "acceleration_meter.h"
+#include "quadrant_gauge.h"
 #include "options_screen.h"
 #include "config.h"
 #include "screen_manager.h"
@@ -26,10 +27,11 @@ bool gmeterCalibrationStored = false;
 
 Preferences preferences;
 TFT_eSPI display = TFT_eSPI();
-const int GAUGE_COUNT = 7;
+const int GAUGE_COUNT = 8;
 const int FALLBACK_GAUGE_INDEX = 5;
 Gauge* gauges[GAUGE_COUNT];
 ScreenManager screenManager;
+Commands commands;
 TaskHandle_t dataTaskHandle;
 SemaphoreHandle_t gaugeMutex;
 unsigned long lastTouchTime = 0;
@@ -72,6 +74,7 @@ void setup() {
     gauges[4] = new DualGauge(&display, 0, outlineColor, needleColor, valueColor);
     gauges[5] = new GMeter(&display);
     gauges[6] = new AccelerationMeter(&display);
+    gauges[7] = new QuadrantGauge(&display, &commands);
 
     if (gmeterCalibrationStored) {
         static_cast<GMeter*>(gauges[5])->setStoredCalibration(mpuCalibrationMatrix, mpuCalibrationBias);
@@ -158,7 +161,6 @@ void updateGMeterCalibrationSettings(const float rotation[3][3], const Vec3& bia
 }
 
 void dataFetchingTask(void* parameter) {
-    Commands commands;
     Adafruit_MPU6050 mpu;
     mpu.begin();
     mpu.setAccelerometerRange(MPU6050_RANGE_2_G);
@@ -225,6 +227,22 @@ void dataFetchingTask(void* parameter) {
                     vTaskDelay(100 / portTICK_PERIOD_MS);
                 }
                 break;
+            case Gauge::QUADRANT_GAUGE:
+                if (obdConnected) {
+                    QuadrantGauge* qg = static_cast<QuadrantGauge*>(gauge);
+                    for (int i = 0; i < 4; i++) {
+                        int commandIndex = qg->getCommandIndexForQuadrant(i);
+                        qg->setQuadrantReading(i, commands.getValueByCommandIndex(commandIndex));
+                    }
+                    vTaskDelay(150 / portTICK_PERIOD_MS);
+                } else {
+                    if (millis() - lastReconnectAttempt > RECONNECT_INTERVAL) {
+                        obdConnected = reconnectToOBD();
+                        lastReconnectAttempt = millis();
+                    }
+                    vTaskDelay(150 / portTICK_PERIOD_MS);
+                }
+                break;
         }
     }
 }
@@ -260,11 +278,33 @@ void loop() {
                         }
                     }
                 }
-            } else if (millis() - touchStartTime > LONG_PRESS_THRESHOLD) {
-                showOptions();
-                ignoreHeldTouchInOptions = true;
-                waitingForReleaseAfterOptions = true;
-                wasTouched = true;  // Don't reset — finger still down
+            } else {
+                bool handledSelectorTouch = false;
+                xSemaphoreTake(gaugeMutex, portMAX_DELAY);
+                Gauge* current = screenManager.getCurrentGauge();
+                if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
+                    QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
+                    if (qg->isSelectorVisible()) {
+                        qg->handleTouch(touch_last_x, touch_last_y);
+                        handledSelectorTouch = true;
+                    }
+                }
+                xSemaphoreGive(gaugeMutex);
+
+                if (!handledSelectorTouch && millis() - touchStartTime > LONG_PRESS_THRESHOLD) {
+                    xSemaphoreTake(gaugeMutex, portMAX_DELAY);
+                    current = screenManager.getCurrentGauge();
+                    if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
+                        QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
+                        qg->openSelectorFromTouch(touch_last_x, touch_last_y);
+                    } else {
+                        showOptions();
+                        ignoreHeldTouchInOptions = true;
+                        waitingForReleaseAfterOptions = true;
+                    }
+                    xSemaphoreGive(gaugeMutex);
+                    wasTouched = true;
+                }
             }
         }
     } else if (wasTouched && !touch_touched()) {
@@ -282,11 +322,22 @@ void loop() {
         }
 
         if (!inOptionsScreen && millis() - touchStartTime < LONG_PRESS_THRESHOLD) {
-            if ((touch_last_x >= 0 && touch_last_x < 30) &&
-                (touch_last_y > 210 && touch_last_y <= 240)) {
-                resetGauge();
-            } else {
-                switchToNextGauge();
+            bool handledByQuadrantSelector = false;
+            xSemaphoreTake(gaugeMutex, portMAX_DELAY);
+            Gauge* current = screenManager.getCurrentGauge();
+            if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
+                QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
+                handledByQuadrantSelector = qg->isSelectorVisible();
+            }
+            xSemaphoreGive(gaugeMutex);
+
+            if (!handledByQuadrantSelector) {
+                if ((touch_last_x >= 0 && touch_last_x < 30) &&
+                    (touch_last_y > 210 && touch_last_y <= 240)) {
+                    resetGauge();
+                } else {
+                    switchToNextGauge();
+                }
             }
         }
     }

--- a/bluetooth.cpp
+++ b/bluetooth.cpp
@@ -7,7 +7,6 @@ BLERemoteCharacteristic* pNotifyChar = nullptr;
 BLEClient* pClient = nullptr;
 boolean connected = false;
 String responseBuffer = "";
-Commands commands;
 
 class MyClientCallback : public BLEClientCallbacks {
   void onConnect(BLEClient* pclient) { connected = true; }
@@ -27,17 +26,18 @@ static void notifyCallback(BLERemoteCharacteristic* pBLERemoteCharacteristic, ui
 }
 
 void intializeELM327() {
+    Commands initCommands;
     // Send initialization commands to ELM327
-    commands.sendCommand("ATZ");     // Reset adapter
-    commands.sendCommand("ATE0");    // Echo off
-    commands.sendCommand("ATL0");    // Linefeeds off
-    commands.sendCommand("ATS0");    // Spaces off
-    commands.sendCommand("ATH0");    // Headers off
-    commands.sendCommand("ATSP 6");  // Set protocol
-    commands.sendCommand("ATSH 7DF"); // Set ECU address
-    commands.sendCommand("AT ST 10"); // Set optimal timeout to 160ms
-    commands.sendCommand("AT AT 2");  // Set aggressive adaptive timing
-    String pidSupport = commands.sendCommand("0100"); // Check supported PIDs
+    initCommands.sendCommand("ATZ");     // Reset adapter
+    initCommands.sendCommand("ATE0");    // Echo off
+    initCommands.sendCommand("ATL0");    // Linefeeds off
+    initCommands.sendCommand("ATS0");    // Spaces off
+    initCommands.sendCommand("ATH0");    // Headers off
+    initCommands.sendCommand("ATSP 6");  // Set protocol
+    initCommands.sendCommand("ATSH 7DF"); // Set ECU address
+    initCommands.sendCommand("AT ST 10"); // Set optimal timeout to 160ms
+    initCommands.sendCommand("AT AT 2");  // Set aggressive adaptive timing
+    String pidSupport = initCommands.sendCommand("0100"); // Check supported PIDs
     Serial.println("PID 0100 response: " + pidSupport);
 }
 

--- a/commands.cpp
+++ b/commands.cpp
@@ -1,28 +1,107 @@
 #include "commands.h"
+#include <algorithm>
 
-// Define the static commandConfig array
-const String Commands::commandConfig[6][8] = {
-    {"RPM", "rpm", "010C", "0", "0", "7000", "2", "0"},
-    {"Engine Load", "%", "0104", "1", "0", "100", "1", "0"},
-    {"Barometric Pressure", "psi", "0133", "2", "0", "37", "1", "14.7"},
-    {"Reference Torque", "lbft", "0163", "3", "0", "500", "2", "445"},
-    {"Actual Torque", "%", "0162", "4", "-125", "125", "1", "0"},
-    {"Speed", "mph", "010D", "5", "0", "158", "1", "0"}
+enum FormulaType {
+    FORMULA_ENGINE_LOAD = 0,
+    FORMULA_TEMP_F,
+    FORMULA_FUEL_TRIM,
+    FORMULA_FUEL_PRESSURE,
+    FORMULA_PRESSURE_PSI,
+    FORMULA_RPM,
+    FORMULA_SPEED_MPH,
+    FORMULA_TIMING_ADVANCE,
+    FORMULA_MAF,
+    FORMULA_RUNTIME_SECONDS,
+    FORMULA_FUEL_PRESSURE_REL_VAC,
+    FORMULA_FUEL_PRESSURE_DIRECT,
+    FORMULA_ABSOLUTE_LOAD,
+    FORMULA_EQUIV_RATIO,
+    FORMULA_MAX_MAF,
+    FORMULA_EVAP_ABS_PRESSURE,
+    FORMULA_EVAP_VAPOR_PA,
+    FORMULA_FUEL_RATE_GPH,
+    FORMULA_TORQUE_PERCENT,
+    FORMULA_REFERENCE_TORQUE_LBFT,
+    FORMULA_FUEL_INJECTION_TIMING,
+    FORMULA_INSTANT_MPG,
+    FORMULA_AVERAGE_MPG
 };
 
-// Constructor initializes A and B
+const pidCommandDefinition Commands::commandConfig[] = {
+    {"Calculated engine load", "%", "0104", 0.0, 100.0, 1, FORMULA_ENGINE_LOAD, "0"},
+    {"Engine coolant temp", "F", "0105", -40.0, 419.0, 1, FORMULA_TEMP_F, "0"},
+    {"Short fuel trim B1", "%", "0106", -100.0, 99.22, 1, FORMULA_FUEL_TRIM, "0"},
+    {"Long fuel trim B1", "%", "0107", -100.0, 99.22, 1, FORMULA_FUEL_TRIM, "0"},
+    {"Short fuel trim B2", "%", "0108", -100.0, 99.22, 1, FORMULA_FUEL_TRIM, "0"},
+    {"Long fuel trim B2", "%", "0109", -100.0, 99.22, 1, FORMULA_FUEL_TRIM, "0"},
+    {"Fuel pressure", "psi", "010A", 0.0, 111.0, 1, FORMULA_FUEL_PRESSURE, "0"},
+    {"Intake MAP", "psi", "010B", 0.0, 37.0, 1, FORMULA_PRESSURE_PSI, "0"},
+    {"Engine RPM", "rpm", "010C", 0.0, 16383.75, 2, FORMULA_RPM, "0"},
+    {"Vehicle speed", "mph", "010D", 0.0, 158.0, 1, FORMULA_SPEED_MPH, "0"},
+    {"Timing advance", "deg", "010E", -64.0, 63.5, 1, FORMULA_TIMING_ADVANCE, "0"},
+    {"Intake air temp", "F", "010F", -40.0, 419.0, 1, FORMULA_TEMP_F, "0"},
+    {"MAF air flow", "g/s", "0110", 0.0, 655.35, 2, FORMULA_MAF, "0"},
+    {"Throttle position", "%", "0111", 0.0, 100.0, 1, FORMULA_ENGINE_LOAD, "0"},
+    {"Run time", "s", "011F", 0.0, 65535.0, 2, FORMULA_RUNTIME_SECONDS, "0"},
+    {"Fuel pressure rel vac", "psi", "0122", 0.0, 750.0, 2, FORMULA_FUEL_PRESSURE_REL_VAC, "0"},
+    {"Fuel pressure direct", "psi", "0123", 0.0, 95025.75, 2, FORMULA_FUEL_PRESSURE_DIRECT, "0"},
+    {"Barometric pressure", "psi", "0133", 0.0, 37.0, 1, FORMULA_PRESSURE_PSI, "0"},
+    {"Absolute load", "%", "0143", 0.0, 25700.0, 2, FORMULA_ABSOLUTE_LOAD, "0"},
+    {"Command equiv ratio", "", "0144", 0.0, 2.0, 2, FORMULA_EQUIV_RATIO, "0"},
+    {"Relative throttle", "%", "0145", 0.0, 100.0, 1, FORMULA_ENGINE_LOAD, "0"},
+    {"Ambient air temp", "F", "0146", -40.0, 419.0, 1, FORMULA_TEMP_F, "0"},
+    {"Max air flow", "g/s", "0150", 0.0, 2550.0, 1, FORMULA_MAX_MAF, "0"},
+    {"Ethanol fuel", "%", "0152", 0.0, 100.0, 1, FORMULA_ENGINE_LOAD, "0"},
+    {"Abs evap vapor", "psi", "0153", 0.0, 47.5, 2, FORMULA_EVAP_ABS_PRESSURE, "0"},
+    {"Evap vapor pressure", "Pa", "0154", -32767.0, 32768.0, 2, FORMULA_EVAP_VAPOR_PA, "0"},
+    {"Fuel rail pressure", "psi", "0159", 0.0, 95025.75, 2, FORMULA_FUEL_PRESSURE_DIRECT, "0"},
+    {"Relative accel pedal", "%", "015A", 0.0, 100.0, 1, FORMULA_ENGINE_LOAD, "0"},
+    {"Engine oil temp", "F", "015C", -40.0, 419.0, 1, FORMULA_TEMP_F, "0"},
+    {"Fuel injection timing", "deg", "015D", -210.0, 301.992, 2, FORMULA_FUEL_INJECTION_TIMING, "0"},
+    {"Engine fuel rate", "Gal/h", "015E", 0.0, 848.7, 2, FORMULA_FUEL_RATE_GPH, "0"},
+    {"Driver demand torque", "%", "0161", -125.0, 125.0, 1, FORMULA_TORQUE_PERCENT, "0"},
+    {"Actual engine torque", "%", "0162", -125.0, 125.0, 1, FORMULA_TORQUE_PERCENT, "0"},
+    {"Engine ref torque", "lb-ft", "0163", 0.0, 48338.0, 2, FORMULA_REFERENCE_TORQUE_LBFT, "0"},
+    {"Instant MPG", "mpg", "0110", 0.0, 100.0, 2, FORMULA_INSTANT_MPG, "0"},
+    {"Average MPG", "mpg", "0110", 0.0, 100.0, 2, FORMULA_AVERAGE_MPG, "0"},
+    {"Trans temperature", "F", "0105", -40.0, 500.0, 1, FORMULA_TEMP_F, "TCM"},
+    {"Trans temperature (1)", "F", "01B4", -40.0, 500.0, 1, FORMULA_TEMP_F, "0"}
+};
+
+const int Commands::commandCount = sizeof(Commands::commandConfig) / sizeof(Commands::commandConfig[0]);
+
 Commands::Commands() : A(0), B(0) {}
 
-// Send a command to the ELM327 and return the response
-String Commands::sendCommand(String pid) {
+String Commands::normalizeHeader(const char* header) const {
+    String rawHeader = String(header);
+    rawHeader.trim();
+    rawHeader.toUpperCase();
+
+    if (rawHeader == "" || rawHeader == "0") {
+        return "7E0";
+    }
+
+    if (rawHeader == "TCM") {
+        return "7E1";
+    }
+
+    return rawHeader;
+}
+
+String Commands::sendCommand(String pid, String header) {
     if (!connected || pWriteChar == nullptr) {
         Serial.println("Cannot send command: No OBD connection");
         return "";
     }
+
+    String selectedHeader = normalizeHeader(header.c_str());
     responseBuffer = "";
+    pWriteChar->writeValue("AT SH " + selectedHeader + "\r");
+    delay(25);
+
     String fullCmd = pid + "\r";
     unsigned long start = millis();
-    Serial.println("Sending command: " + pid);
+    Serial.println("Sending command: " + pid + " on header: " + selectedHeader);
     pWriteChar->writeValue(fullCmd);
     for (int i = 0; i < 1000; i++) {
         delay(1);
@@ -39,7 +118,6 @@ String Commands::sendCommand(String pid) {
     return "";
 }
 
-// Parse the response and set A and B
 void Commands::parsePIDResponse(String response, String pid, int numBytes) {
     String compact = "";
     for (int i = 0; i < response.length(); i++) {
@@ -78,16 +156,69 @@ void Commands::parsePIDResponse(String response, String pid, int numBytes) {
     Serial.printf("Parsed PID %s => A: %d, B: %d from %s\n", pid.c_str(), A, B, compact.c_str());
 }
 
-// Query a command and return the calculated value
-double Commands::query(int commandIndex) {
-    if (!connected || pWriteChar == nullptr) {
-        return 0.0; // Return default value if not connected
+double Commands::calculateValue(int commandIndex) const {
+    switch (commandConfig[commandIndex].formula) {
+        case FORMULA_ENGINE_LOAD:
+            return ((double)A * 100.00) / 255.00;
+        case FORMULA_TEMP_F:
+            return (((double)A - 40.0) * 9.0 / 5.0) + 32.0;
+        case FORMULA_FUEL_TRIM:
+            return (((double)A - 128.0) * 100.0 / 128.0);
+        case FORMULA_FUEL_PRESSURE:
+            return ((double)A * 3.0 * 0.145);
+        case FORMULA_PRESSURE_PSI:
+            return ((double)A * 0.145);
+        case FORMULA_RPM:
+            return ((((double)A * 256.0) + (double)B) / 4.0);
+        case FORMULA_SPEED_MPH:
+            return ((double)A * 0.621371);
+        case FORMULA_TIMING_ADVANCE:
+            return (((double)A / 2.0) - 64.0);
+        case FORMULA_MAF:
+            return ((((double)A * 256.0) + (double)B) / 100.0);
+        case FORMULA_RUNTIME_SECONDS:
+            return (((double)A * 256.0) + (double)B);
+        case FORMULA_FUEL_PRESSURE_REL_VAC:
+            return ((((double)A * 256.0 + (double)B) * 0.079) * 0.145);
+        case FORMULA_FUEL_PRESSURE_DIRECT:
+            return ((((double)A * 256.0 + (double)B) * 10.0) * 0.145);
+        case FORMULA_ABSOLUTE_LOAD:
+            return ((((double)A * 256.0) + (double)B) * 100.0 / 255.0);
+        case FORMULA_EQUIV_RATIO:
+            return ((((double)A * 256.0) + (double)B) / 32768.0);
+        case FORMULA_MAX_MAF:
+            return ((double)A * 10.0);
+        case FORMULA_EVAP_ABS_PRESSURE:
+            return (((((double)A * 256.0) + (double)B) / 200.0) * 0.145);
+        case FORMULA_EVAP_VAPOR_PA:
+            return ((((double)A * 256.0) + (double)B) - 32768.0);
+        case FORMULA_FUEL_RATE_GPH:
+            return ((((double)A * 256.0) + (double)B) * 0.05 * 0.264172);
+        case FORMULA_TORQUE_PERCENT:
+            return ((double)A - 125.0);
+        case FORMULA_REFERENCE_TORQUE_LBFT:
+            return ((((double)A * 256.0) + (double)B) * 0.7376);
+        case FORMULA_FUEL_INJECTION_TIMING:
+            return (((((double)A * 256.0) + (double)B) - 26880.0) / 128.0);
+        default:
+            return 0.0;
     }
-    String command = commandConfig[commandIndex][2];
-    int numBytes = commandConfig[commandIndex][6].toInt();
-    int formula = commandConfig[commandIndex][3].toInt();
-    String response = sendCommand(command);
+}
 
+double Commands::queryCommand(int commandIndex) {
+    if (!connected || pWriteChar == nullptr) {
+        return 0.0;
+    }
+
+    if (commandIndex < 0 || commandIndex >= commandCount) {
+        return 0.0;
+    }
+
+    String command = commandConfig[commandIndex].pid;
+    int numBytes = commandConfig[commandIndex].numBytes;
+    String header = commandConfig[commandIndex].header;
+
+    String response = sendCommand(command, header);
     if (response == "") {
         return 0.0;
     }
@@ -97,67 +228,53 @@ double Commands::query(int commandIndex) {
         return 0.0;
     }
 
-    double val = 0.0;
-    switch (formula) {
-        case 0:
-            val = ((((double)A * 256.00) + (double)B) / 4.0);
-            return val;
-        case 1:
-            val = ((double)A * 100.00) / 255.00;
-            return val;
-        case 2:
-            val = ((double)A * 0.145);
-            return val;
-        case 3:
-            val = (((double)A * 256.00) + (double)B) * 0.7376;
-            return val;
-        case 4:
-            val = (double)A - 125.00;
-            return val;
-        case 5:
-            val = A * 0.621371;
-            return val;
-        default:
-            return -1.0;
+    if (commandConfig[commandIndex].formula == FORMULA_INSTANT_MPG ||
+        commandConfig[commandIndex].formula == FORMULA_AVERAGE_MPG) {
+        return 0.0;
     }
+
+    return calculateValue(commandIndex);
 }
 
 double Commands::getReading(int selectedReading) {
     if (!connected || pWriteChar == nullptr) {
-        return 0.0; // Return default value if not connected
+        return 0.0;
     }
+
+    const int RPM_INDEX = 8;
+    const int ENGINE_LOAD_INDEX = 0;
+    const int BARO_INDEX = 17;
+    const int REF_TORQUE_INDEX = 33;
+    const int ACTUAL_TORQUE_INDEX = 32;
+    const int SPEED_INDEX = 9;
+
     switch (selectedReading) {
         case 0:
-            // RPM
-            return query(0);
+            return queryCommand(RPM_INDEX);
         case 1: {
-            // Boost
-            double rpm = query(0);
-            double load = query(1);
-            double baro = query(2);
-            double fRpm = std::min(1.0, (rpm - 1500) / (4000 - 1500));
+            double rpm = queryCommand(RPM_INDEX);
+            double load = queryCommand(ENGINE_LOAD_INDEX);
+            double baro = queryCommand(BARO_INDEX);
+            double fRpm = std::min(1.0, (rpm - 1500.0) / (4000.0 - 1500.0));
             fRpm = std::max(0.0, fRpm);
 
             double boost = 22.0 * (load / 100.0) * fRpm;
+            (void)baro;
             return boost;
         }
         case 2: {
-            // Torque
-            double ref = query(3);
-            double actual = query(4);
+            double ref = queryCommand(REF_TORQUE_INDEX);
+            double actual = queryCommand(ACTUAL_TORQUE_INDEX);
             return (ref * (actual / 100.0));
         }
         case 3: {
-            // Horsepower
-            double rpm = query(0);
-            double refTorque = query(3);
-            double actualTorque = query(4);
+            double rpm = queryCommand(RPM_INDEX);
+            double refTorque = queryCommand(REF_TORQUE_INDEX);
+            double actualTorque = queryCommand(ACTUAL_TORQUE_INDEX);
             return ((refTorque * (actualTorque / 100.0)) * rpm) / 5252.0;
         }
-        case 5: {
-            // Speed
-            return query(5);
-        }
+        case 5:
+            return queryCommand(SPEED_INDEX);
         default:
             return 0.0;
     }
@@ -172,13 +289,74 @@ struct dualGaugeReading Commands::getDualReading() {
         return x;
     }
 
-    // Get RPM, Reference Torque, and Torque
-    double rpm = query(0);
-    double refTorque = query(3);
-    double actTorque = query(4);
+    const int RPM_INDEX = 8;
+    const int REF_TORQUE_INDEX = 33;
+    const int ACTUAL_TORQUE_INDEX = 32;
+
+    double rpm = queryCommand(RPM_INDEX);
+    double refTorque = queryCommand(REF_TORQUE_INDEX);
+    double actTorque = queryCommand(ACTUAL_TORQUE_INDEX);
     double torque = (refTorque * (actTorque / 100.0));
     double hp = ((refTorque * (actTorque / 100.0)) * rpm) / 5252.0;
     x.readings[0] = torque;
     x.readings[1] = hp;
     return x;
 }
+
+int Commands::getCommandCount() const {
+    return commandCount;
+}
+
+String Commands::getCommandLabel(int commandIndex) const {
+    if (commandIndex < 0 || commandIndex >= commandCount) {
+        return "";
+    }
+    return String(commandConfig[commandIndex].label);
+}
+
+String Commands::getCommandUnits(int commandIndex) const {
+    if (commandIndex < 0 || commandIndex >= commandCount) {
+        return "";
+    }
+    return String(commandConfig[commandIndex].units);
+}
+
+double Commands::getValueByCommandIndex(int commandIndex) {
+    if (commandIndex < 0 || commandIndex >= commandCount) {
+        return 0.0;
+    }
+
+    static double averageMpg = 0.0;
+    static bool averageInit = false;
+
+    int formula = commandConfig[commandIndex].formula;
+    if (formula == FORMULA_INSTANT_MPG || formula == FORMULA_AVERAGE_MPG) {
+        double speedMph = queryCommand(9);
+        double maf = queryCommand(12);
+
+        if (maf <= 0.01) {
+            return 0.0;
+        }
+
+        double instantMpg = speedMph * 710.7 / maf;
+        instantMpg = constrain(instantMpg, 0.0, 100.0);
+
+        if (!averageInit) {
+            averageMpg = instantMpg;
+            averageInit = true;
+        } else {
+            averageMpg = (averageMpg * 0.95) + (instantMpg * 0.05);
+        }
+
+        if (formula == FORMULA_INSTANT_MPG) {
+            return instantMpg;
+        }
+
+        return constrain(averageMpg, 0.0, 100.0);
+    }
+
+    return queryCommand(commandIndex);
+}
+
+void Commands::initializeOBD() {}
+

--- a/commands.h
+++ b/commands.h
@@ -7,20 +7,39 @@ struct dualGaugeReading {
     double readings[2];
 };
 
+struct pidCommandDefinition {
+    const char* label;
+    const char* units;
+    const char* pid;
+    double minValue;
+    double maxValue;
+    int numBytes;
+    int formula;
+    const char* header;
+};
+
 class Commands {
 private:
     int A;
     int B;
-    static const String commandConfig[6][8];
+    static const pidCommandDefinition commandConfig[];
+    static const int commandCount;
     void parsePIDResponse(String response, String pid, int numBytes);
-    double query(int commandIndex);
+    String normalizeHeader(const char* header) const;
+    double queryCommand(int commandIndex);
+    double calculateValue(int commandIndex) const;
 
 public:
     Commands();
     double getReading(int selectedGauge);
     struct dualGaugeReading getDualReading();
     void initializeOBD();
-    String sendCommand(String pid);
+    String sendCommand(String pid, String header = "0");
+
+    int getCommandCount() const;
+    String getCommandLabel(int commandIndex) const;
+    String getCommandUnits(int commandIndex) const;
+    double getValueByCommandIndex(int commandIndex);
 };
 
 #endif // COMMANDS_H

--- a/gauge.h
+++ b/gauge.h
@@ -12,7 +12,8 @@ public:
         NEEDLE_GAUGE,
         DUAL_GAUGE,
         G_METER,
-        ACCELERATION_METER
+        ACCELERATION_METER,
+        QUADRANT_GAUGE
     };
 
     Gauge(TFT_eSPI* display) : display(display) {}

--- a/quadrant_gauge.h
+++ b/quadrant_gauge.h
@@ -1,0 +1,222 @@
+#ifndef QUADRANT_GAUGE_H
+#define QUADRANT_GAUGE_H
+
+#include "gauge.h"
+#include "commands.h"
+
+class QuadrantGauge : public Gauge {
+public:
+    QuadrantGauge(TFT_eSPI* display, Commands* commands) :
+        Gauge(display),
+        commands(commands),
+        screen(display),
+        selector(display),
+        selectorOpen(false),
+        selectedQuadrant(0),
+        pageStart(0) {
+        selectedCommands[0] = 8;   // RPM
+        selectedCommands[1] = 9;   // Speed
+        selectedCommands[2] = 1;   // Coolant temp
+        selectedCommands[3] = 29;  // Fuel rate
+        for (int i = 0; i < 4; i++) {
+            values[i] = 0.0;
+        }
+    }
+
+    void initialize() override {
+        display->fillScreen(DISPLAY_BG_COLOR);
+        if (!screen.createSprite(DISPLAY_WIDTH, DISPLAY_HEIGHT)) {
+            Serial.println("Failed to create QuadrantGauge screen sprite");
+        }
+
+        if (!selector.createSprite(DISPLAY_WIDTH - 30, DISPLAY_HEIGHT - 30)) {
+            Serial.println("Failed to create QuadrantGauge selector sprite");
+        }
+
+        drawQuadrants();
+    }
+
+    void render(double) override {
+        drawQuadrants();
+        if (selectorOpen) {
+            drawSelector();
+        }
+    }
+
+    void reset() override {
+        selectorOpen = false;
+        pageStart = 0;
+        drawQuadrants();
+    }
+
+    void displayStats(float, double, double) override {}
+
+    GaugeType getType() const override {
+        return QUADRANT_GAUGE;
+    }
+
+    uint32_t getCurrentNeedleColor() override { return TFT_WHITE; }
+    uint32_t getCurrentOutlineColor() override { return TFT_WHITE; }
+    uint32_t getCurrentValueColor() override { return TFT_WHITE; }
+
+    void setQuadrantReading(int quadrant, double value) {
+        if (quadrant < 0 || quadrant >= 4) {
+            return;
+        }
+        values[quadrant] = value;
+    }
+
+    bool isSelectorVisible() const {
+        return selectorOpen;
+    }
+
+    void openSelectorFromTouch(uint16_t x, uint16_t y) {
+        selectedQuadrant = getQuadrantFromTouch(x, y);
+        pageStart = 0;
+        selectorOpen = true;
+        drawSelector();
+    }
+
+    bool handleTouch(uint16_t x, uint16_t y) {
+        if (!selectorOpen) {
+            return false;
+        }
+
+        int localX = x - 15;
+        int localY = y - 15;
+        if (localX < 0 || localY < 0 || localX >= (DISPLAY_WIDTH - 30) || localY >= (DISPLAY_HEIGHT - 30)) {
+            selectorOpen = false;
+            return true;
+        }
+
+        const int rowHeight = 24;
+        const int top = 32;
+        const int visibleRows = 7;
+
+        int prevY = DISPLAY_HEIGHT - 65;
+        int nextY = DISPLAY_HEIGHT - 65;
+        if (localY >= prevY && localY < prevY + 22 && localX >= 10 && localX < 90) {
+            pageStart = max(0, pageStart - visibleRows);
+            return true;
+        }
+
+        if (localY >= nextY && localY < nextY + 22 && localX >= (DISPLAY_WIDTH - 30 - 90) && localX < (DISPLAY_WIDTH - 30 - 10)) {
+            int maxStart = max(0, commands->getCommandCount() - visibleRows);
+            pageStart = min(maxStart, pageStart + visibleRows);
+            return true;
+        }
+
+        for (int i = 0; i < visibleRows; i++) {
+            int rowY = top + i * rowHeight;
+            if (localY >= rowY && localY < rowY + rowHeight - 2) {
+                int commandIndex = pageStart + i;
+                if (commandIndex < commands->getCommandCount()) {
+                    selectedCommands[selectedQuadrant] = commandIndex;
+                    selectorOpen = false;
+                }
+                return true;
+            }
+        }
+
+        return true;
+    }
+
+    int getCommandIndexForQuadrant(int quadrant) const {
+        if (quadrant < 0 || quadrant >= 4) {
+            return 0;
+        }
+        return selectedCommands[quadrant];
+    }
+
+private:
+    Commands* commands;
+    TFT_eSprite screen;
+    TFT_eSprite selector;
+    int selectedCommands[4];
+    double values[4];
+    bool selectorOpen;
+    int selectedQuadrant;
+    int pageStart;
+
+    int getQuadrantFromTouch(uint16_t x, uint16_t y) {
+        bool right = x >= DISPLAY_WIDTH / 2;
+        bool lower = y >= DISPLAY_HEIGHT / 2;
+
+        if (!right && !lower) return 0;
+        if (right && !lower) return 1;
+        if (!right && lower) return 2;
+        return 3;
+    }
+
+    void drawQuadrants() {
+        screen.fillSprite(DISPLAY_BG_COLOR);
+        screen.drawLine(DISPLAY_WIDTH / 2, 0, DISPLAY_WIDTH / 2, DISPLAY_HEIGHT, TFT_DARKGREY);
+        screen.drawLine(0, DISPLAY_HEIGHT / 2, DISPLAY_WIDTH, DISPLAY_HEIGHT / 2, TFT_DARKGREY);
+
+        for (int i = 0; i < 4; i++) {
+            int originX = (i % 2) * (DISPLAY_WIDTH / 2);
+            int originY = (i / 2) * (DISPLAY_HEIGHT / 2);
+            int boxW = DISPLAY_WIDTH / 2;
+            int boxH = DISPLAY_HEIGHT / 2;
+
+            String label = commands->getCommandLabel(selectedCommands[i]);
+            String units = commands->getCommandUnits(selectedCommands[i]);
+
+            screen.setTextColor(TFT_WHITE, DISPLAY_BG_COLOR);
+            screen.setFreeFont(FONT_BOLD_12);
+            screen.drawString(label, originX + 8, originY + 8);
+            screen.unloadFont();
+
+            screen.setFreeFont(FONT_BOLD_18);
+            String valueText = String(values[i], 1);
+            int valueWidth = screen.textWidth(valueText);
+            screen.drawString(valueText, originX + (boxW - valueWidth) / 2, originY + (boxH / 2) - 10);
+            screen.unloadFont();
+
+            screen.setFreeFont(FONT_NORMAL_12);
+            screen.drawString(units, originX + 8, originY + boxH - 22);
+            screen.unloadFont();
+        }
+
+        screen.pushSprite(0, 0);
+    }
+
+    void drawSelector() {
+        selector.fillSprite(TFT_BLACK);
+        selector.drawRect(0, 0, selector.width(), selector.height(), TFT_WHITE);
+        selector.setTextColor(TFT_WHITE, TFT_BLACK);
+        selector.setTextFont(1);
+
+        String title = "Select value for quadrant " + String(selectedQuadrant + 1);
+        selector.drawString(title, 8, 8, 2);
+
+        const int rowHeight = 24;
+        const int top = 32;
+        const int visibleRows = 7;
+
+        for (int i = 0; i < visibleRows; i++) {
+            int commandIndex = pageStart + i;
+            if (commandIndex >= commands->getCommandCount()) {
+                break;
+            }
+
+            int rowY = top + i * rowHeight;
+            bool active = (selectedCommands[selectedQuadrant] == commandIndex);
+            uint16_t bg = active ? TFT_DARKGREEN : TFT_DARKGREY;
+            selector.fillRect(6, rowY, selector.width() - 12, rowHeight - 2, bg);
+
+            String rowLabel = commands->getCommandLabel(commandIndex);
+            selector.drawString(rowLabel, 12, rowY + 6, 2);
+        }
+
+        selector.fillRect(10, selector.height() - 35, 80, 22, TFT_BLUE);
+        selector.drawString("Prev", 28, selector.height() - 30, 2);
+
+        selector.fillRect(selector.width() - 90, selector.height() - 35, 80, 22, TFT_BLUE);
+        selector.drawString("Next", selector.width() - 72, selector.height() - 30, 2);
+
+        selector.pushSprite(15, 15);
+    }
+};
+
+#endif


### PR DESCRIPTION
### Motivation
- Add a new quadrant-style gauge that can show four selectable OBD values and allow the user to choose each quadrant's PID via a selector. 
- Refactor the OBD command handling to support a centralized `Commands` API with PID metadata, per-command headers, and improved value calculation logic. 
- Integrate the new gauge into the main app flow and ensure touch/selector interactions and data polling work with the new Commands API.

### Description
- Added a new `QuadrantGauge` implementation (`quadrant_gauge.h`) that renders four value panels, supports a pop-up selector, and provides APIs `isSelectorVisible()`, `openSelectorFromTouch()`, `handleTouch()`, `getCommandIndexForQuadrant()` and `setQuadrantReading()`.
- Extended `Gauge::GaugeType` with `QUADRANT_GAUGE` and updated main code to include the new gauge by increasing `GAUGE_COUNT` and constructing `new QuadrantGauge(&display, &commands)` in `setup()`.
- Refactored the commands/OBD subsystem: replaced the old ad-hoc command table with a typed `pidCommandDefinition` array, added `Commands::sendCommand(pid, header)`, `queryCommand()`, `calculateValue()`, `getValueByCommandIndex()`, and accessor helpers `getCommandCount()`, `getCommandLabel()`, and `getCommandUnits()` in `commands.h/cpp`.
- Updated BLE/ELM327 initialization in `bluetooth.cpp` to avoid a global `Commands` instance and use a local `initCommands` for the adapter init sequence.
- Modified `dataFetchingTask` to support `QUADRANT_GAUGE` polling (reads values via `commands.getValueByCommandIndex(...)`) and removed a duplicate local `Commands` object in the task.
- Enhanced touch handling in `ESP32OBDGauge.ino` to route long-press and short-touch events to quadrant selector interactions when the current gauge is a `QuadrantGauge`.

### Testing
- Performed a full firmware build for ESP32 using the project's Arduino/PlatformIO build configuration and the build completed successfully.
- Verified compilation of modified modules `commands.cpp/.h`, `quadrant_gauge.h`, `ESP32OBDGauge.ino`, `bluetooth.cpp`, and `gauge.h` with no compile errors.
- No automated unit tests exist for these components, so no unit/integration test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85711465c832393e6e9621c818dde)