### PR TITLE
Fix quadrant touch handling and button label overflow

### DIFF
--- a/ESP32OBDGauge.ino
+++ b/ESP32OBDGauge.ino
@@ -120,6 +120,7 @@ void dataFetchingTask(void* parameter) {
 
 void loop() {
     static bool wasTouched = false;
+    static bool touchHandledForCurrentPress = false;
     static bool ignoreHeldTouchInOptions = false;
     static bool waitingForReleaseAfterOptions = false;
     static bool justExitedOptions = false;
@@ -133,6 +134,7 @@ void loop() {
             if (!wasTouched) {
                 wasTouched = true;
                 touchStartTime = millis();
+                touchHandledForCurrentPress = false;
 
                 if (inOptionsScreen && !waitingForReleaseAfterOptions) {
                     ignoreHeldTouchInOptions = false;
@@ -140,8 +142,9 @@ void loop() {
             }
 
             if (inOptionsScreen) {
-                if (!ignoreHeldTouchInOptions) {
+                if (!ignoreHeldTouchInOptions && !touchHandledForCurrentPress) {
                     if (touch_last_x >= 0 && touch_last_y >= 0) {
+                        touchHandledForCurrentPress = true;
                         if (!optionsScreen->handleTouch(touch_last_x, touch_last_y)) {
                             exitOptions();
                             justExitedOptions = true;
@@ -153,11 +156,13 @@ void loop() {
                 showOptions();
                 ignoreHeldTouchInOptions = true;
                 waitingForReleaseAfterOptions = true;
+                touchHandledForCurrentPress = true;
                 wasTouched = true;  // Don't reset — finger still down
             }
         }
     } else if (wasTouched && !touch_touched()) {
         wasTouched = false;
+        touchHandledForCurrentPress = false;
 
         if (waitingForReleaseAfterOptions) {
             // Now we can allow interaction again

--- a/options_screen.h
+++ b/options_screen.h
@@ -201,10 +201,7 @@ private:
                 int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
                 screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
                 screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
+                drawButtonLabel(labels[i][j], x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
             }
         }
         screenSprite.pushSprite(0, 0);
@@ -255,10 +252,7 @@ private:
                 int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
                 screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
                 screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
+                drawButtonLabel(labels[i][j], x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
             }
         }
         screenSprite.pushSprite(0, 0);
@@ -281,13 +275,51 @@ private:
                 int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
                 screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
                 screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
+                drawButtonLabel(labels[i][j], x, y, BUTTON_WIDTH, BUTTON_HEIGHT);
             }
         }
         screenSprite.pushSprite(0, 0);
+    }
+
+    void drawButtonLabel(const char* label, int x, int y, int width, int height) {
+        const int horizontalPadding = 6;
+        String text = String(label);
+        int maxTextWidth = width - (horizontalPadding * 2);
+        int lineHeight = screenSprite.fontHeight();
+
+        if (screenSprite.textWidth(text) <= maxTextWidth) {
+            int textX = x + (width - screenSprite.textWidth(text)) / 2;
+            int textY = y + (height - lineHeight) / 2;
+            screenSprite.setCursor(textX, textY);
+            screenSprite.print(text);
+            return;
+        }
+
+        int splitIndex = text.indexOf(' ');
+        if (splitIndex == -1) {
+            String truncated = text;
+            while (truncated.length() > 0 && screenSprite.textWidth(truncated + "...") > maxTextWidth) {
+                truncated.remove(truncated.length() - 1);
+            }
+            truncated += "...";
+            int textX = x + (width - screenSprite.textWidth(truncated)) / 2;
+            int textY = y + (height - lineHeight) / 2;
+            screenSprite.setCursor(textX, textY);
+            screenSprite.print(truncated);
+            return;
+        }
+
+        String line1 = text.substring(0, splitIndex);
+        String line2 = text.substring(splitIndex + 1);
+        int line1Width = screenSprite.textWidth(line1);
+        int line2Width = screenSprite.textWidth(line2);
+        int totalHeight = lineHeight * 2;
+        int firstLineY = y + (height - totalHeight) / 2;
+
+        screenSprite.setCursor(x + (width - line1Width) / 2, firstLineY);
+        screenSprite.print(line1);
+        screenSprite.setCursor(x + (width - line2Width) / 2, firstLineY + lineHeight);
+        screenSprite.print(line2);
     }
 
     void drawColorPicker() {


### PR DESCRIPTION
### Motivation
- Prevent the options/quadrant long-press flow from immediately re-processing the same held touch which caused the options screen to flash and not allow selecting a new data type. 
- Ensure menu button labels never overflow their button area so text remains readable and fits within each section.

### Description
- Added a static flag `touchHandledForCurrentPress` in `loop()` and gated options touch processing with it to ensure each physical press is handled only once and the long-press -> options transition does not immediately retrigger actions. 
- Set and cleared `touchHandledForCurrentPress` appropriately when showing the options screen and when the finger is released to restore normal touch behavior. 
- Introduced `drawButtonLabel(const char* label, int x, int y, int width, int height)` in `options_screen.h` to render button text safely by centering short labels, wrapping two-word labels onto two lines, and truncating long single-word labels with an ellipsis. 
- Replaced direct label drawing in the main, Bluetooth and color menus with calls to `drawButtonLabel` so all menu buttons use the overflow-safe renderer.

### Testing
- Ran `rg -n "touchHandledForCurrentPress|drawButtonLabel" ESP32OBDGauge.ino options_screen.h` to verify the new symbols are present; command succeeded. 
- Ran `git diff --check` to validate there are no whitespace/diff issues; command succeeded. 
- Attempted `arduino-cli version` to run a local build check but the `arduino-cli` tool is not available in this environment so that check failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8c516856083239443f8a669a4e77d)