### PR TITLE
Fix quadrant UI interaction and add OBD query diagnostics

### DIFF
--- a/ESP32OBDGauge.ino
+++ b/ESP32OBDGauge.ino
@@ -12,7 +12,7 @@
 #include "config.h"
 #include "screen_manager.h"
 
-bool TESTMODE = true;
+bool TESTMODE = false;
 
 /*
     Variables for settings stored in flash memory
@@ -252,6 +252,7 @@ void loop() {
     static bool ignoreHeldTouchInOptions = false;
     static bool waitingForReleaseAfterOptions = false;
     static bool justExitedOptions = false;
+    static bool waitingForReleaseAfterQuadrantSelector = false;
     static unsigned long touchStartTime = 0;
     const unsigned long LONG_PRESS_THRESHOLD = 1000; // 1 second
     const unsigned long DEBOUNCE_MS = 200;
@@ -285,7 +286,9 @@ void loop() {
                 if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
                     QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
                     if (qg->isSelectorVisible()) {
-                        qg->handleTouch(touch_last_x, touch_last_y);
+                        if (!waitingForReleaseAfterQuadrantSelector) {
+                            qg->handleTouch(touch_last_x, touch_last_y);
+                        }
                         handledSelectorTouch = true;
                     }
                 }
@@ -297,6 +300,7 @@ void loop() {
                     if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
                         QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
                         qg->openSelectorFromTouch(touch_last_x, touch_last_y);
+                        waitingForReleaseAfterQuadrantSelector = true;
                     } else {
                         showOptions();
                         ignoreHeldTouchInOptions = true;
@@ -316,6 +320,11 @@ void loop() {
             ignoreHeldTouchInOptions = false;
         }
 
+        if (waitingForReleaseAfterQuadrantSelector) {
+            waitingForReleaseAfterQuadrantSelector = false;
+            return;
+        }
+
         if (justExitedOptions) {
             justExitedOptions = false;
             return;
@@ -332,8 +341,11 @@ void loop() {
             xSemaphoreGive(gaugeMutex);
 
             if (!handledByQuadrantSelector) {
-                if ((touch_last_x >= 0 && touch_last_x < 30) &&
-                    (touch_last_y > 210 && touch_last_y <= 240)) {
+                if ((touch_last_x >= 0 && touch_last_x <= 40) &&
+                    (touch_last_y >= 0 && touch_last_y <= 40)) {
+                    Serial.println("Last OBD diagnostic: " + commands.getLastQueryDiagnostic());
+                } else if ((touch_last_x >= 0 && touch_last_x < 30) &&
+                           (touch_last_y > 210 && touch_last_y <= 240)) {
                     resetGauge();
                 } else {
                     switchToNextGauge();

--- a/commands.cpp
+++ b/commands.cpp
@@ -70,7 +70,14 @@ const pidCommandDefinition Commands::commandConfig[] = {
 
 const int Commands::commandCount = sizeof(Commands::commandConfig) / sizeof(Commands::commandConfig[0]);
 
-Commands::Commands() : A(0), B(0) {}
+Commands::Commands() :
+    A(0),
+    B(0),
+    lastQueryError(QUERY_OK),
+    lastQueryCommandIndex(-1),
+    lastQueryPid(""),
+    lastQueryHeader(""),
+    lastQueryResponse("") {}
 
 String Commands::normalizeHeader(const char* header) const {
     String rawHeader = String(header);
@@ -91,6 +98,7 @@ String Commands::normalizeHeader(const char* header) const {
 String Commands::sendCommand(String pid, String header) {
     if (!connected || pWriteChar == nullptr) {
         Serial.println("Cannot send command: No OBD connection");
+        lastQueryError = QUERY_NOT_CONNECTED;
         return "";
     }
 
@@ -115,6 +123,7 @@ String Commands::sendCommand(String pid, String header) {
         }
     }
     Serial.println("Command " + pid + " timed out. Response buffer: " + responseBuffer);
+    lastQueryError = QUERY_TIMEOUT;
     return "";
 }
 
@@ -206,11 +215,16 @@ double Commands::calculateValue(int commandIndex) const {
 }
 
 double Commands::queryCommand(int commandIndex) {
+    lastQueryCommandIndex = commandIndex;
+    lastQueryResponse = "";
+
     if (!connected || pWriteChar == nullptr) {
+        lastQueryError = QUERY_NOT_CONNECTED;
         return 0.0;
     }
 
     if (commandIndex < 0 || commandIndex >= commandCount) {
+        lastQueryError = QUERY_INVALID_INDEX;
         return 0.0;
     }
 
@@ -218,13 +232,22 @@ double Commands::queryCommand(int commandIndex) {
     int numBytes = commandConfig[commandIndex].numBytes;
     String header = commandConfig[commandIndex].header;
 
+    lastQueryPid = command;
+    lastQueryHeader = normalizeHeader(header.c_str());
+    lastQueryError = QUERY_OK;
+
     String response = sendCommand(command, header);
+    lastQueryResponse = response;
     if (response == "") {
+        if (lastQueryError == QUERY_OK) {
+            lastQueryError = QUERY_TIMEOUT;
+        }
         return 0.0;
     }
 
     parsePIDResponse(response, command, numBytes);
     if (A < 0 || (numBytes > 1 && B < 0)) {
+        lastQueryError = QUERY_PARSE_FAILED;
         return 0.0;
     }
 
@@ -233,6 +256,7 @@ double Commands::queryCommand(int commandIndex) {
         return 0.0;
     }
 
+    lastQueryError = QUERY_OK;
     return calculateValue(commandIndex);
 }
 
@@ -356,6 +380,44 @@ double Commands::getValueByCommandIndex(int commandIndex) {
     }
 
     return queryCommand(commandIndex);
+}
+
+String Commands::getLastQueryDiagnostic() const {
+    String status = "OK";
+    switch (lastQueryError) {
+        case QUERY_OK:
+            status = "OK";
+            break;
+        case QUERY_NOT_CONNECTED:
+            status = "NOT_CONNECTED";
+            break;
+        case QUERY_INVALID_INDEX:
+            status = "INVALID_INDEX";
+            break;
+        case QUERY_TIMEOUT:
+            status = "TIMEOUT";
+            break;
+        case QUERY_PARSE_FAILED:
+            status = "PARSE_FAILED";
+            break;
+    }
+
+    String label = "n/a";
+    if (lastQueryCommandIndex >= 0 && lastQueryCommandIndex < commandCount) {
+        label = String(commandConfig[lastQueryCommandIndex].label);
+    }
+
+    String rawResponse = lastQueryResponse;
+    rawResponse.replace("\r", " ");
+    rawResponse.replace("\n", " ");
+    rawResponse.trim();
+
+    return "Status=" + status +
+           " | Index=" + String(lastQueryCommandIndex) +
+           " | Label=" + label +
+           " | PID=" + lastQueryPid +
+           " | Header=" + lastQueryHeader +
+           " | Raw='" + rawResponse + "'";
 }
 
 void Commands::initializeOBD() {}

--- a/commands.h
+++ b/commands.h
@@ -20,8 +20,21 @@ struct pidCommandDefinition {
 
 class Commands {
 private:
+    enum QueryError {
+        QUERY_OK = 0,
+        QUERY_NOT_CONNECTED,
+        QUERY_INVALID_INDEX,
+        QUERY_TIMEOUT,
+        QUERY_PARSE_FAILED
+    };
+
     int A;
     int B;
+    QueryError lastQueryError;
+    int lastQueryCommandIndex;
+    String lastQueryPid;
+    String lastQueryHeader;
+    String lastQueryResponse;
     static const pidCommandDefinition commandConfig[];
     static const int commandCount;
     void parsePIDResponse(String response, String pid, int numBytes);
@@ -40,6 +53,7 @@ public:
     String getCommandLabel(int commandIndex) const;
     String getCommandUnits(int commandIndex) const;
     double getValueByCommandIndex(int commandIndex);
+    String getLastQueryDiagnostic() const;
 };
 
 #endif // COMMANDS_H

--- a/quadrant_gauge.h
+++ b/quadrant_gauge.h
@@ -138,6 +138,24 @@ private:
     int selectedQuadrant;
     int pageStart;
 
+    String fitTextToWidth(const String& text, int maxWidth) {
+        if (screen.textWidth(text) <= maxWidth) {
+            return text;
+        }
+
+        String fitted = text;
+        while (fitted.length() > 0 && screen.textWidth(fitted + "...") > maxWidth) {
+            fitted.remove(fitted.length() - 1);
+        }
+
+        return fitted + "...";
+    }
+
+    void drawFittedText(const String& text, int x, int y, int maxWidth) {
+        String fitted = fitTextToWidth(text, maxWidth);
+        screen.drawString(fitted, x, y);
+    }
+
     int getQuadrantFromTouch(uint16_t x, uint16_t y) {
         bool right = x >= DISPLAY_WIDTH / 2;
         bool lower = y >= DISPLAY_HEIGHT / 2;
@@ -163,8 +181,11 @@ private:
             String units = commands->getCommandUnits(selectedCommands[i]);
 
             screen.setTextColor(TFT_WHITE, DISPLAY_BG_COLOR);
+            const int textLeft = originX + 8;
+            const int textMaxWidth = boxW - 16;
+
             screen.setFreeFont(FONT_BOLD_12);
-            screen.drawString(label, originX + 8, originY + 8);
+            drawFittedText(label, textLeft, originY + 8, textMaxWidth);
             screen.unloadFont();
 
             screen.setFreeFont(FONT_BOLD_18);
@@ -174,9 +195,17 @@ private:
             screen.unloadFont();
 
             screen.setFreeFont(FONT_NORMAL_12);
-            screen.drawString(units, originX + 8, originY + boxH - 22);
+            drawFittedText(units, textLeft, originY + boxH - 22, textMaxWidth);
             screen.unloadFont();
         }
+
+        screen.setTextColor(TFT_YELLOW, DISPLAY_BG_COLOR);
+        screen.setTextFont(1);
+        String diag = commands->getLastQueryDiagnostic();
+        if (diag.length() > 52) {
+            diag = diag.substring(0, 52) + "...";
+        }
+        screen.drawString(diag, 2, DISPLAY_HEIGHT - 10, 1);
 
         screen.pushSprite(0, 0);
     }
@@ -205,7 +234,14 @@ private:
             uint16_t bg = active ? TFT_DARKGREEN : TFT_DARKGREY;
             selector.fillRect(6, rowY, selector.width() - 12, rowHeight - 2, bg);
 
-            String rowLabel = commands->getCommandLabel(commandIndex);
+            String originalLabel = commands->getCommandLabel(commandIndex);
+            String rowLabel = originalLabel;
+            while (rowLabel.length() > 0 && selector.textWidth(rowLabel, 2) > selector.width() - 24) {
+                rowLabel.remove(rowLabel.length() - 1);
+            }
+            if (rowLabel != originalLabel) {
+                rowLabel += "...";
+            }
             selector.drawString(rowLabel, 12, rowY + 6, 2);
         }
 


### PR DESCRIPTION
### Motivation
- Prevent quadrant titles/units from overflowing their quadrant area and make the quadrant selector usable with long-press gestures. 
- Restore live OBD data flow (fix no-data symptom) and add a small on-device mechanism to diagnose why command queries fail (timeouts/parsing/connection). 

### Description
- Added width-aware truncation helpers and used them to draw quadrant labels and units, and to trim long selector row labels so text fits inside its box (`quadrant_gauge.h`).
- Changed long-press selector handling to set a release gate so the same held touch that opens the selector is not immediately processed as a selection/close (`ESP32OBDGauge.ino`).
- Disabled hardcoded test mode by setting `TESTMODE = false` so real OBD connection logic is used again (`ESP32OBDGauge.ino`).
- Added diagnostic tracking to `Commands`: `QueryError` states, last query metadata (`PID`, `header`, `command index`, `raw response`) and `getLastQueryDiagnostic()` to expose a compact diagnostic string (`commands.h`, `commands.cpp`).
- Surface diagnostics to the user via a compact diagnostics line at the bottom of the quadrant screen and a serial diagnostic print when tapping the top-left corner (`quadrant_gauge.h`, `ESP32OBDGauge.ino`).

### Testing
- Verified repository state and commit succeeded using `git status` and `git commit` (changes staged and committed successfully). — succeeded.
- Inspected modified files with `rg`/`sed` to confirm inserted helpers, touch gating and diagnostic plumbing are present — succeeded.
- Attempted to run `arduino-cli version` to perform a full firmware build; `arduino-cli` is not available in this environment so an actual compile/flash was not performed — failed (tool missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9982c63d483239f291be417c4b1ef)