### PR TITLE
Fix OBD PID query flow by waiting for header command completion

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -103,10 +103,29 @@ String Commands::sendCommand(String pid, String header) {
     }
 
     String selectedHeader = normalizeHeader(header.c_str());
-    responseBuffer = "";
-    pWriteChar->writeValue("AT SH " + selectedHeader + "\r");
-    delay(25);
+    bool isATCommand = pid.startsWith("AT");
 
+    if (!isATCommand) {
+        responseBuffer = "";
+        pWriteChar->writeValue("AT SH " + selectedHeader + "\r");
+
+        bool headerReady = false;
+        for (int i = 0; i < 250; i++) {
+            delay(1);
+            if (responseBuffer.indexOf(">") != -1) {
+                headerReady = true;
+                break;
+            }
+        }
+
+        if (!headerReady) {
+            Serial.println("Header set timed out for " + selectedHeader + ". Response buffer: " + responseBuffer);
+            lastQueryError = QUERY_TIMEOUT;
+            return "";
+        }
+    }
+
+    responseBuffer = "";
     String fullCmd = pid + "\r";
     unsigned long start = millis();
     Serial.println("Sending command: " + pid + " on header: " + selectedHeader);
@@ -421,4 +440,3 @@ String Commands::getLastQueryDiagnostic() const {
 }
 
 void Commands::initializeOBD() {}
-


### PR DESCRIPTION
### Motivation
- PID queries were intermittently parsing `STOPPED`/`OK` fragments and failing with "PID not found" because the PID request could be sent before the adapter finished processing the `AT SH` header command.

### Description
- Updated `Commands::sendCommand` to detect AT control commands using `pid.startsWith("AT")` and skip header-setting for those commands.
- For non-AT commands, send `AT SH <header>` and wait (up to ~250ms) for the ELM prompt `>` to appear in `responseBuffer` before sending the PID query, returning a `QUERY_TIMEOUT` if the prompt is not observed.
- Cleared `responseBuffer` before setting the header and again immediately before sending the actual PID to avoid stale fragments contaminating PID parsing, while preserving the original PID-response wait loop.

### Testing
- Ran `git diff --check` which completed cleanly.
- Verified repository status with `git status --short` to confirm only the intended file was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b26299ac8323acbf1b6cc0f4da7a)