### PR TITLE
Add reusable touch gesture handling and modular UI components

### DIFF
--- a/ESP32OBDGauge.ino
+++ b/ESP32OBDGauge.ino
@@ -8,8 +8,8 @@
 #include "g_meter.h"
 #include "acceleration_meter.h"
 #include "quadrant_gauge.h"
-#include "options_screen.h"
 #include "config.h"
+#include "options_screen.h"
 #include "screen_manager.h"
 
 bool TESTMODE = false;
@@ -257,7 +257,9 @@ void loop() {
     const unsigned long LONG_PRESS_THRESHOLD = 1000; // 1 second
     const unsigned long DEBOUNCE_MS = 200;
 
-    if (touch_touched()) {
+    bool currentlyTouched = touch_touched();
+
+    if (currentlyTouched) {
         if (millis() - lastTouchTime > DEBOUNCE_MS) {
             lastTouchTime = millis();
             if (!wasTouched) {
@@ -311,7 +313,7 @@ void loop() {
                 }
             }
         }
-    } else if (wasTouched && !touch_touched()) {
+    } else if (wasTouched) {
         wasTouched = false;
 
         if (waitingForReleaseAfterOptions) {
@@ -350,6 +352,37 @@ void loop() {
                 } else {
                     switchToNextGauge();
                 }
+            }
+        }
+    }
+
+    TouchGesture gesture;
+    if (touch_getGesture(&gesture)) {
+        if (inOptionsScreen) {
+            if (!optionsScreen->handleTouchGesture(gesture)) {
+                exitOptions();
+            }
+        } else {
+            if (gesture.type == TouchGesture::SWIPE_LEFT) {
+                switchToNextGauge();
+            } else if (gesture.type == TouchGesture::SWIPE_RIGHT) {
+                xSemaphoreTake(gaugeMutex, portMAX_DELAY);
+                int previousGauge = screenManager.getCurrentGaugeIndex() - 1;
+                if (previousGauge < 0) {
+                    previousGauge = GAUGE_COUNT - 1;
+                }
+                screenManager.setCurrentGauge(previousGauge);
+                currentGauge = screenManager.getCurrentGaugeIndex();
+                Gauge* current = screenManager.getCurrentGauge();
+                if (current != nullptr) {
+                    current->initialize();
+                }
+                updateCurrentGaugeSettings(currentGauge);
+                xSemaphoreGive(gaugeMutex);
+            } else if (gesture.type == TouchGesture::SWIPE_DOWN) {
+                resetGauge();
+            } else if (gesture.type == TouchGesture::PINCH_IN || gesture.type == TouchGesture::PINCH_OUT) {
+                showOptions();
             }
         }
     }

--- a/options_screen.h
+++ b/options_screen.h
@@ -2,17 +2,18 @@
 #define OPTIONS_SCREEN_H
 
 #include <TFT_eSPI.h>
+#include "config.h"
+#include "ui_library.h"
+#include "touch.h"
+#include "gauge.h"
+#include "needle_gauge.h"
+#include "dual_gauge.h"
+#include "g_meter.h"
 
 class OptionsScreen {
 public:
-    OptionsScreen(TFT_eSPI* display, Gauge** gauges, int numGauges) : 
-        display(display), 
-        gauges(gauges), 
-        numGauges(numGauges), 
-        screenSprite(display),
-        state(MAIN_MENU),
-        bluetoothState(MAIN_BLUETOOTH_MENU),
-        colorState(MAIN_COLOR_MENU) {}
+    OptionsScreen(TFT_eSPI* display, Gauge** gauges, int numGauges)
+        : display(display), gauges(gauges), numGauges(numGauges), screenSprite(display), state(MAIN_MENU), colorState(MAIN_COLOR_MENU) {}
 
     void initialize() {
         display->fillScreen(TFT_BLACK);
@@ -24,40 +25,37 @@ public:
     }
 
     bool handleTouch(uint16_t x, uint16_t y) {
-        Serial.println(String(state));
-        if (state == MAIN_MENU) {
-            // Check main menu buttons
-            for (int i = 0; i < 2; i++) {
-                for (int j = 0; j < 2; j++) {
-                    int bx = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                    int by = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                    if (x >= bx && x < bx + BUTTON_WIDTH && y >= by && y < by + BUTTON_HEIGHT) {
-                        if (i == 0 && j == 0) { // G-meter calibration
-                            state = ABOUT;
-                            drawAboutMenu();
-                            return true;
-                        } else if (i == 0 && j == 1) { // Bluetooth settings
-                            state = BLUETOOTH;
-                            drawBluetoothMenu();
-                            return true;
-                        } else if (i == 1 && j == 0) { // Color settings
-                            state = COLOR;
-                            drawColorMenu();
-                            return true;
-                        } else if (i == 1 && j == 1) { // Exit
-                            return false;
-                        }
-                    }
-                }
+        return handleTouchGesture({TouchGesture::TAP, static_cast<int16_t>(x), static_cast<int16_t>(y), static_cast<int16_t>(x), static_cast<int16_t>(y), 0, 0, 1.0f});
+    }
+
+    bool handleTouchGesture(const TouchGesture& gesture) {
+        if (gesture.type == TouchGesture::SWIPE_RIGHT || gesture.type == TouchGesture::SWIPE_DOWN) {
+            if (state == MAIN_MENU) {
+                return false;
             }
-            return true; // No button touched so dont process any input or change screens
-        } else if (state == ABOUT) {
+            goBack();
+            return true;
+        }
+
+        int16_t x = gesture.endX;
+        int16_t y = gesture.endY;
+
+        if (state == MAIN_MENU) {
+            return handleMainMenuTouch(x, y);
+        }
+
+        if (state == ABOUT) {
             return handleAboutTouch(x, y);
-        } else if (state == BLUETOOTH) {
+        }
+
+        if (state == BLUETOOTH) {
             return handleBluetoothTouch(x, y);
-        } else if (state == COLOR) {
+        }
+
+        if (state == COLOR) {
             return handleColorTouch(x, y);
         }
+
         return true;
     }
 
@@ -66,162 +64,184 @@ private:
     Gauge** gauges;
     int numGauges;
     TFT_eSprite screenSprite;
-    
+
     enum ScreenState { MAIN_MENU, ABOUT, BLUETOOTH, COLOR };
-    enum BluetoothState { MAIN_BLUETOOTH_MENU, PAIRING_MENU, STATS_MENU };
     enum ColorState { MAIN_COLOR_MENU, NEEDLE_COLOR, OUTLINE_COLOR, VALUE_COLOR };
     ScreenState state;
-    BluetoothState bluetoothState;
     ColorState colorState;
 
-    // Button dimensions
     static const int BUTTON_WIDTH = 140;
     static const int BUTTON_HEIGHT = 100;
     static const int BUTTON_SPACING = 20;
     static const int BUTTON_MARGIN = 10;
     static const int COLOR_SWATCH_SIZE = 60;
 
-    // Color options
     uint16_t colorOptions[12] = {
         TFT_RED, TFT_GREEN, TFT_BLUE, TFT_YELLOW,
-        TFT_ORANGE, TFT_DARKGREEN, TFT_CYAN, TFT_GOLD, 
+        TFT_ORANGE, TFT_DARKGREEN, TFT_CYAN, TFT_GOLD,
         TFT_VIOLET, TFT_PURPLE, TFT_SILVER, TFT_WHITE
     };
 
-    bool handleAboutTouch(uint16_t x, uint16_t y) {
-        int buttonWidth = 190;
-        int buttonHeight = 55;
-        int calibrateX = (DISPLAY_WIDTH - buttonWidth) / 2;
-        int calibrateY = 90;
-        int backX = calibrateX;
-        int backY = 160;
+    UIButton buildGridButton(int id, int row, int col, const char* label, uint16_t color = TFT_DARKGREY) {
+        UIRect rect = {
+            static_cast<int16_t>(BUTTON_MARGIN + col * (BUTTON_WIDTH + BUTTON_SPACING)),
+            static_cast<int16_t>(BUTTON_MARGIN + row * (BUTTON_HEIGHT + BUTTON_SPACING)),
+            static_cast<int16_t>(BUTTON_WIDTH),
+            static_cast<int16_t>(BUTTON_HEIGHT)
+        };
+        return UIButton(id, label, rect, color, TFT_WHITE, TFT_WHITE);
+    }
 
-        if (x >= calibrateX && x < calibrateX + buttonWidth && y >= calibrateY && y < calibrateY + buttonHeight) {
+    void drawButtons(UIButton* buttons, int count) {
+        for (int i = 0; i < count; i++) {
+            buttons[i].draw(screenSprite, 2, 1);
+        }
+    }
+
+    int hitButton(UIButton* buttons, int count, int16_t x, int16_t y) {
+        for (int i = 0; i < count; i++) {
+            if (buttons[i].hitTest(x, y)) {
+                return buttons[i].getId();
+            }
+        }
+        return -1;
+    }
+
+    bool handleMainMenuTouch(uint16_t x, uint16_t y) {
+        UIButton buttons[4] = {
+            buildGridButton(0, 0, 0, "G-Meter"),
+            buildGridButton(1, 0, 1, "Bluetooth"),
+            buildGridButton(2, 1, 0, "Color"),
+            buildGridButton(3, 1, 1, "Exit")
+        };
+
+        int buttonId = hitButton(buttons, 4, x, y);
+        switch (buttonId) {
+            case 0:
+                state = ABOUT;
+                drawAboutMenu();
+                return true;
+            case 1:
+                state = BLUETOOTH;
+                drawBluetoothMenu();
+                return true;
+            case 2:
+                state = COLOR;
+                colorState = MAIN_COLOR_MENU;
+                drawColorMenu();
+                return true;
+            case 3:
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    bool handleAboutTouch(uint16_t x, uint16_t y) {
+        UIButton buttons[2] = {
+            UIButton(0, "Start Calibration", {65, 90, 190, 55}, TFT_DARKGREEN),
+            UIButton(1, "Back", {65, 160, 190, 55})
+        };
+
+        int buttonId = hitButton(buttons, 2, x, y);
+        if (buttonId == 0) {
             triggerGMeterCalibration();
             drawAboutMenu();
             return true;
         }
-
-        if (x >= backX && x < backX + buttonWidth && y >= backY && y < backY + buttonHeight) {
+        if (buttonId == 1) {
             state = MAIN_MENU;
             drawMainMenu();
             return true;
         }
-
         return true;
     }
 
     bool handleColorTouch(uint16_t x, uint16_t y) {
         if (colorState == MAIN_COLOR_MENU) {
-            // Check main menu buttons
-            for (int i = 0; i < 2; i++) {
-                for (int j = 0; j < 2; j++) {
-                    int bx = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                    int by = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                    if (x >= bx && x < bx + BUTTON_WIDTH && y >= by && y < by + BUTTON_HEIGHT) {
-                        if (i == 0 && j == 0) { // Needle color
-                            colorState = NEEDLE_COLOR;
-                            drawColorPicker();  
-                            return true;
-                        } else if (i == 0 && j == 1) { // Outline color
-                            colorState = OUTLINE_COLOR;
-                            drawColorPicker();
-                            return true;
-                        } else if (i == 1 && j == 0) { // Value color
-                            colorState = VALUE_COLOR;
-                            drawColorPicker();
-                            return true;
-                        } else if (i == 1 && j == 1) { // Exit
-                            colorState = MAIN_COLOR_MENU;
-                            state = MAIN_MENU;
-                            drawMainMenu();
-                            return true;
-                        }
-                    }
-                }
-            }
-            return true; // No button touched so dont process any input or change screens
-        } else {
-            // Not in main menu, only one sub menu to set color, so check color swatches
-            for (int i = 0; i < 3; i++) {
-                for (int j = 0; j < 4; j++) {
-                    int cx = BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                    int cy = BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                    if (x >= cx && x < cx + COLOR_SWATCH_SIZE && y >= cy && y < cy + COLOR_SWATCH_SIZE) {
-                        // Handle color update based on screen state
-                        uint16_t color = colorOptions[i * 4 + j];
-                        switch (colorState) {
-                            case NEEDLE_COLOR:
-                                updateNeedleColor(color);
-                                break;
-                            case OUTLINE_COLOR:
-                                updateOutlineColor(color);
-                                break;
-                            case VALUE_COLOR:
-                                updateValueColor(color);
-                                break;
-                            default:
-                                break;
-                        }
+            UIButton buttons[4] = {
+                buildGridButton(0, 0, 0, "Needle Color"),
+                buildGridButton(1, 0, 1, "Outline Color"),
+                buildGridButton(2, 1, 0, "Value Color"),
+                buildGridButton(3, 1, 1, "Exit")
+            };
 
-                        // Return to the main color menu
-                        colorState = MAIN_COLOR_MENU;
-                        drawColorMenu();
-                        return true;
+            int buttonId = hitButton(buttons, 4, x, y);
+            if (buttonId == 0) {
+                colorState = NEEDLE_COLOR;
+                drawColorPicker();
+            } else if (buttonId == 1) {
+                colorState = OUTLINE_COLOR;
+                drawColorPicker();
+            } else if (buttonId == 2) {
+                colorState = VALUE_COLOR;
+                drawColorPicker();
+            } else if (buttonId == 3) {
+                state = MAIN_MENU;
+                colorState = MAIN_COLOR_MENU;
+                drawMainMenu();
+            }
+            return true;
+        }
+
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 4; j++) {
+                UIRect swatch = {
+                    static_cast<int16_t>(BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING)),
+                    static_cast<int16_t>(BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING)),
+                    COLOR_SWATCH_SIZE,
+                    COLOR_SWATCH_SIZE
+                };
+
+                if (swatch.contains(x, y)) {
+                    uint16_t color = colorOptions[i * 4 + j];
+                    if (colorState == NEEDLE_COLOR) {
+                        updateNeedleColor(color);
+                    } else if (colorState == OUTLINE_COLOR) {
+                        updateOutlineColor(color);
+                    } else if (colorState == VALUE_COLOR) {
+                        updateValueColor(color);
                     }
+                    colorState = MAIN_COLOR_MENU;
+                    drawColorMenu();
+                    return true;
                 }
             }
-            return true; // No button touched so dont process any input or change screens
         }
+
+        return true;
     }
 
     bool handleBluetoothTouch(uint16_t x, uint16_t y) {
-        // Check main menu buttons
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int bx = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int by = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                if (x >= bx && x < bx + BUTTON_WIDTH && y >= by && y < by + BUTTON_HEIGHT) {
-                    if (i == 0 && j == 0) { // Pair device
-                        // To be implemented
-                    } else if (i == 0 && j == 1) { // Delete device
-                        
-                    } else if (i == 1 && j == 0) { // Stats
-                        
-                    } else if (i == 1 && j == 1) { // Exit
-                        state = MAIN_MENU;
-                        drawMainMenu();
-                        return true;
-                    }
-                }
-            }
+        UIButton buttons[4] = {
+            buildGridButton(0, 0, 0, "Pair Device"),
+            buildGridButton(1, 0, 1, "Stats"),
+            buildGridButton(2, 1, 0, "Remove Device"),
+            buildGridButton(3, 1, 1, "Exit")
+        };
+
+        int buttonId = hitButton(buttons, 4, x, y);
+        if (buttonId == 1) {
+            drawBluetoothStats();
+            return true;
         }
-        return true; // No button touched so dont process any input or change screens
+        if (buttonId == 3) {
+            state = MAIN_MENU;
+            drawMainMenu();
+            return true;
+        }
+        return true;
     }
 
     void drawMainMenu() {
         screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 2x2 grid of buttons
-        const char* labels[2][2] = {
-            {"G-Meter", "Bluetooth"},
-            {"Color", "Exit"}
+        UIButton buttons[4] = {
+            buildGridButton(0, 0, 0, "G-Meter"),
+            buildGridButton(1, 0, 1, "Bluetooth"),
+            buildGridButton(2, 1, 0, "Color"),
+            buildGridButton(3, 1, 1, "Exit")
         };
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int x = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
-                screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
-            }
-        }
+        drawButtons(buttons, 4);
         screenSprite.pushSprite(0, 0);
     }
 
@@ -233,92 +253,91 @@ private:
 
         String title = "G-Meter Calibration";
         int titleWidth = screenSprite.textWidth(title);
-        int x = DISPLAY_CENTER_X - (titleWidth / 2);
-        screenSprite.setCursor(x, 24);
+        screenSprite.setCursor(DISPLAY_CENTER_X - (titleWidth / 2), 24);
         screenSprite.print(title);
 
         screenSprite.setTextSize(1);
         String text = "Park on flat ground before calibrating.";
         int textWidth = screenSprite.textWidth(text);
-        x = DISPLAY_CENTER_X - (textWidth / 2);
-        screenSprite.setCursor(x, 55);
+        screenSprite.setCursor(DISPLAY_CENTER_X - (textWidth / 2), 55);
         screenSprite.print(text);
 
-        int buttonWidth = 190;
-        int buttonHeight = 55;
-        int buttonX = (DISPLAY_WIDTH - buttonWidth) / 2;
-
-        screenSprite.fillRect(buttonX, 90, buttonWidth, buttonHeight, TFT_DARKGREEN);
-        screenSprite.drawRect(buttonX, 90, buttonWidth, buttonHeight, TFT_WHITE);
-        String calibrate = "Start Calibration";
-        int calibrateWidth = screenSprite.textWidth(calibrate);
-        int calibrateHeight = screenSprite.fontHeight();
-        screenSprite.setCursor(buttonX + (buttonWidth - calibrateWidth) / 2, 90 + (buttonHeight - calibrateHeight) / 2);
-        screenSprite.print(calibrate);
-
-        screenSprite.fillRect(buttonX, 160, buttonWidth, buttonHeight, TFT_DARKGREY);
-        screenSprite.drawRect(buttonX, 160, buttonWidth, buttonHeight, TFT_WHITE);
-        String back = "Back";
-        int backWidth = screenSprite.textWidth(back);
-        int backHeight = screenSprite.fontHeight();
-        screenSprite.setCursor(buttonX + (buttonWidth - backWidth) / 2, 160 + (buttonHeight - backHeight) / 2);
-        screenSprite.print(back);
-
+        UIButton buttons[2] = {
+            UIButton(0, "Start Calibration", {65, 90, 190, 55}, TFT_DARKGREEN),
+            UIButton(1, "Back", {65, 160, 190, 55})
+        };
+        drawButtons(buttons, 2);
         screenSprite.pushSprite(0, 0);
     }
 
     void drawBluetoothMenu() {
         screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 2x2 grid of buttons
-        const char* labels[2][2] = {
-            {"Pair Device", "Stats"},
-            {"Remove Device", "Exit"}
+        UIButton buttons[4] = {
+            buildGridButton(0, 0, 0, "Pair Device"),
+            buildGridButton(1, 0, 1, "Stats"),
+            buildGridButton(2, 1, 0, "Remove Device"),
+            buildGridButton(3, 1, 1, "Exit")
         };
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int x = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
-                screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
-            }
-        }
+        drawButtons(buttons, 4);
+        screenSprite.pushSprite(0, 0);
+    }
+
+    void drawBluetoothStats() {
+        screenSprite.fillSprite(TFT_BLACK);
+
+        UITable statsTable;
+        statsTable.configure({20, 20, 280, 140}, 4, 2);
+        statsTable.setCell(0, 0, "Metric");
+        statsTable.setCell(0, 1, "Value");
+        statsTable.setCell(1, 0, "Connected");
+        statsTable.setCell(1, 1, "Yes");
+        statsTable.setCell(2, 0, "Device");
+        statsTable.setCell(2, 1, "OBD BLE");
+        statsTable.setCell(3, 0, "Version");
+        statsTable.setCell(3, 1, SOFTWARE_VERSION);
+        statsTable.draw(screenSprite, true);
+
+        UIButton backButton(0, "Back", {65, 180, 190, 45});
+        backButton.draw(screenSprite, 2, 1);
         screenSprite.pushSprite(0, 0);
     }
 
     void drawColorMenu() {
         screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 2x2 grid of buttons
-        const char* labels[2][2] = {
-            {"Needle Color", "Outline Color"},
-            {"Value Color", "Exit"}
+        UIButton buttons[4] = {
+            buildGridButton(0, 0, 0, "Needle Color"),
+            buildGridButton(1, 0, 1, "Outline Color"),
+            buildGridButton(2, 1, 0, "Value Color"),
+            buildGridButton(3, 1, 1, "Exit")
         };
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int x = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
-                screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
+        drawButtons(buttons, 4);
+        screenSprite.pushSprite(0, 0);
+    }
+
+    void drawColorPicker() {
+        screenSprite.fillSprite(TFT_BLACK);
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 4; j++) {
+                int x = BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
+                int y = BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
+                screenSprite.fillRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, colorOptions[i * 4 + j]);
+                screenSprite.drawRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, TFT_WHITE);
             }
         }
         screenSprite.pushSprite(0, 0);
     }
 
+    void goBack() {
+        if (state == COLOR && colorState != MAIN_COLOR_MENU) {
+            colorState = MAIN_COLOR_MENU;
+            drawColorMenu();
+            return;
+        }
+
+        state = MAIN_MENU;
+        colorState = MAIN_COLOR_MENU;
+        drawMainMenu();
+    }
 
     void triggerGMeterCalibration() {
         for (int i = 0; i < numGauges; i++) {
@@ -329,31 +348,11 @@ private:
         }
     }
 
-    void drawColorPicker() {
-        screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 4x3 grid of color swatches
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 4; j++) {
-                int x = BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, colorOptions[i * 4 + j]);
-                screenSprite.drawRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, TFT_WHITE);
-            }
-        }
-
-        screenSprite.pushSprite(0, 0);
-    }
-
     void updateNeedleColor(uint16_t color) {
         for (int i = 0; i < numGauges; i++) {
             if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) {
                 static_cast<NeedleGauge*>(gauges[i])->setNeedleColor(color);
             }
-
             if (gauges[i]->getType() == Gauge::DUAL_GAUGE) {
                 static_cast<DualGauge*>(gauges[i])->setNeedleColor(color);
             }
@@ -365,7 +364,6 @@ private:
             if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) {
                 static_cast<NeedleGauge*>(gauges[i])->setOutlineColor(color);
             }
- 
             if (gauges[i]->getType() == Gauge::DUAL_GAUGE) {
                 static_cast<DualGauge*>(gauges[i])->setOutlineColor(color);
             }
@@ -377,10 +375,9 @@ private:
             if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) {
                 static_cast<NeedleGauge*>(gauges[i])->setValueColor(color);
             }
-
             if (gauges[i]->getType() == Gauge::DUAL_GAUGE) {
                 static_cast<DualGauge*>(gauges[i])->setValueColor(color);
-            }            
+            }
         }
     }
 };

--- a/touch.h
+++ b/touch.h
@@ -1,25 +1,73 @@
-#include <FT6336.h>
+#ifndef TOUCH_H
+#define TOUCH_H
 
- #define TOUCH_FT6336
- #define TOUCH_FT6336_SCL 22
- #define TOUCH_FT6336_SDA 21
- #define TOUCH_FT6336_INT 15
- #define TOUCH_FT6336_RST 13
- #define TOUCH_MAP_X1 0
- #define TOUCH_MAP_X2 240
- #define TOUCH_MAP_Y1 0
- #define TOUCH_MAP_Y2 320
+#include <FT6336.h>
+#include <math.h>
+
+#define TOUCH_FT6336
+#define TOUCH_FT6336_SCL 22
+#define TOUCH_FT6336_SDA 21
+#define TOUCH_FT6336_INT 15
+#define TOUCH_FT6336_RST 13
+#define TOUCH_MAP_X1 0
+#define TOUCH_MAP_X2 240
+#define TOUCH_MAP_Y1 0
+#define TOUCH_MAP_Y2 320
+
+struct TouchGesture {
+  enum Type {
+    NONE,
+    TAP,
+    LONG_PRESS,
+    SWIPE_LEFT,
+    SWIPE_RIGHT,
+    SWIPE_UP,
+    SWIPE_DOWN,
+    PINCH_IN,
+    PINCH_OUT
+  };
+
+  Type type;
+  int16_t startX;
+  int16_t startY;
+  int16_t endX;
+  int16_t endY;
+  int16_t deltaX;
+  int16_t deltaY;
+  float pinchScale;
+};
 
 int touch_last_x = 0, touch_last_y = 0;
-unsigned short int width=0, height=0, rotation,min_x=0,max_x=0,min_y=0,max_y=0;
+unsigned short int width = 0, height = 0, rotation, min_x = 0, max_x = 0, min_y = 0, max_y = 0;
 
 FT6336 ts = FT6336(TOUCH_FT6336_SDA, TOUCH_FT6336_SCL, TOUCH_FT6336_INT, TOUCH_FT6336_RST, max(TOUCH_MAP_X1, TOUCH_MAP_X2), max(TOUCH_MAP_Y1, TOUCH_MAP_Y2));
 
-void touch_init(unsigned short int w, unsigned short int h,unsigned char r)
-{
-  width = w; 
+static bool touch_active = false;
+static bool touch_has_second = false;
+static int16_t touch_start_x = 0;
+static int16_t touch_start_y = 0;
+static unsigned long touch_start_time = 0;
+static float pinch_start_distance = 0.0f;
+static TouchGesture pendingGesture = {TouchGesture::NONE, 0, 0, 0, 0, 0, 0, 1.0f};
+
+inline int16_t mapTouchX(int rawX) {
+  return map(rawX, min_x, max_x, 0, width - 1);
+}
+
+inline int16_t mapTouchY(int rawY) {
+  return map(rawY, min_y, max_y, 0, height - 1);
+}
+
+inline float touchDistance(int16_t x1, int16_t y1, int16_t x2, int16_t y2) {
+  float dx = static_cast<float>(x2 - x1);
+  float dy = static_cast<float>(y2 - y1);
+  return sqrtf((dx * dx) + (dy * dy));
+}
+
+void touch_init(unsigned short int w, unsigned short int h, unsigned char r) {
+  width = w;
   height = h;
-  switch (r){
+  switch (r) {
     case ROTATION_NORMAL:
     case ROTATION_INVERTED:
       min_x = TOUCH_MAP_X1;
@@ -41,37 +89,107 @@ void touch_init(unsigned short int w, unsigned short int h,unsigned char r)
   ts.setRotation(r);
 }
 
-bool touch_touched(void)
-{
+bool touch_touched(void) {
   ts.read();
-  if (ts.isTouched)
-  {
-    touch_last_x = map(ts.points[0].x, min_x, max_x, 0, width - 1);
-    touch_last_y = map(ts.points[0].y, min_y, max_y, 0, height - 1);
+  if (ts.isTouched) {
+    touch_last_x = mapTouchX(ts.points[0].x);
+    touch_last_y = mapTouchY(ts.points[0].y);
+
+    bool secondTouch = (ts.points[1].x > 0 || ts.points[1].y > 0);
+
+    if (!touch_active) {
+      touch_active = true;
+      touch_has_second = secondTouch;
+      touch_start_x = touch_last_x;
+      touch_start_y = touch_last_y;
+      touch_start_time = millis();
+
+      if (secondTouch) {
+        int16_t x2 = mapTouchX(ts.points[1].x);
+        int16_t y2 = mapTouchY(ts.points[1].y);
+        pinch_start_distance = touchDistance(touch_last_x, touch_last_y, x2, y2);
+      } else {
+        pinch_start_distance = 0.0f;
+      }
+    }
+
     Serial.printf("Touched at x: %.1d. y: %.1d\n", touch_last_x, touch_last_y);
     return true;
   }
-  else
-  {
-    return false;
+
+  if (touch_active) {
+    unsigned long duration = millis() - touch_start_time;
+    int16_t dx = touch_last_x - touch_start_x;
+    int16_t dy = touch_last_y - touch_start_y;
+    int16_t adx = abs(dx);
+    int16_t ady = abs(dy);
+
+    pendingGesture = {TouchGesture::NONE, touch_start_x, touch_start_y, static_cast<int16_t>(touch_last_x), static_cast<int16_t>(touch_last_y), dx, dy, 1.0f};
+
+    if (touch_has_second && pinch_start_distance > 1.0f) {
+      float currentDistance = pinch_start_distance;
+      if (ts.points[1].x > 0 || ts.points[1].y > 0) {
+        int16_t x2 = mapTouchX(ts.points[1].x);
+        int16_t y2 = mapTouchY(ts.points[1].y);
+        currentDistance = touchDistance(touch_last_x, touch_last_y, x2, y2);
+      }
+      float scale = currentDistance / pinch_start_distance;
+      pendingGesture.pinchScale = scale;
+      if (scale > 1.20f) {
+        pendingGesture.type = TouchGesture::PINCH_OUT;
+      } else if (scale < 0.85f) {
+        pendingGesture.type = TouchGesture::PINCH_IN;
+      }
+    }
+
+    if (pendingGesture.type == TouchGesture::NONE) {
+      if (adx > 50 || ady > 50) {
+        if (adx > ady) {
+          pendingGesture.type = dx > 0 ? TouchGesture::SWIPE_RIGHT : TouchGesture::SWIPE_LEFT;
+        } else {
+          pendingGesture.type = dy > 0 ? TouchGesture::SWIPE_DOWN : TouchGesture::SWIPE_UP;
+        }
+      } else if (duration > 1000) {
+        pendingGesture.type = TouchGesture::LONG_PRESS;
+      } else {
+        pendingGesture.type = TouchGesture::TAP;
+      }
+    }
+
+    touch_active = false;
+    touch_has_second = false;
+    pinch_start_distance = 0.0f;
   }
+
+  return false;
 }
 
 bool touch_getXY(uint16_t* x, uint16_t* y) {
-    if (touch_touched()) {
-        *x = touch_last_x;
-        *y = touch_last_y;
-        return true;
-    }
+  if (touch_touched()) {
+    *x = touch_last_x;
+    *y = touch_last_y;
+    return true;
+  }
+  return false;
+}
+
+bool touch_getGesture(TouchGesture* gesture) {
+  if (pendingGesture.type == TouchGesture::NONE || gesture == nullptr) {
     return false;
-}
+  }
 
-bool touch_has_signal(void)
-{
+  *gesture = pendingGesture;
+  pendingGesture.type = TouchGesture::NONE;
+  pendingGesture.pinchScale = 1.0f;
   return true;
 }
 
-bool touch_released(void)
-{
+bool touch_has_signal(void) {
   return true;
 }
+
+bool touch_released(void) {
+  return !touch_active;
+}
+
+#endif

--- a/ui_library.h
+++ b/ui_library.h
@@ -1,0 +1,124 @@
+#ifndef UI_LIBRARY_H
+#define UI_LIBRARY_H
+
+#include <TFT_eSPI.h>
+
+struct UIRect {
+    int16_t x;
+    int16_t y;
+    int16_t w;
+    int16_t h;
+
+    bool contains(int16_t px, int16_t py) const {
+        return px >= x && px < (x + w) && py >= y && py < (y + h);
+    }
+};
+
+class UIButton {
+public:
+    UIButton() : id(-1), label(""), visible(true), enabled(true), bgColor(TFT_DARKGREY), borderColor(TFT_WHITE), textColor(TFT_WHITE) {
+        bounds = {0, 0, 0, 0};
+    }
+
+    UIButton(int buttonId, const char* buttonLabel, const UIRect& rect, uint16_t bg = TFT_DARKGREY, uint16_t border = TFT_WHITE, uint16_t text = TFT_WHITE)
+        : id(buttonId), label(buttonLabel), bounds(rect), visible(true), enabled(true), bgColor(bg), borderColor(border), textColor(text) {}
+
+    void draw(TFT_eSprite& sprite, uint8_t textFont = 2, uint8_t textSize = 1) const {
+        if (!visible) {
+            return;
+        }
+
+        sprite.fillRect(bounds.x, bounds.y, bounds.w, bounds.h, enabled ? bgColor : TFT_DARKGREY);
+        sprite.drawRect(bounds.x, bounds.y, bounds.w, bounds.h, borderColor);
+        sprite.setTextFont(textFont);
+        sprite.setTextSize(textSize);
+        sprite.setTextColor(textColor);
+
+        int textWidth = sprite.textWidth(label);
+        int textHeight = sprite.fontHeight();
+        sprite.setCursor(bounds.x + (bounds.w - textWidth) / 2, bounds.y + (bounds.h - textHeight) / 2);
+        sprite.print(label);
+    }
+
+    bool hitTest(int16_t px, int16_t py) const {
+        return visible && enabled && bounds.contains(px, py);
+    }
+
+    int getId() const { return id; }
+    const UIRect& getBounds() const { return bounds; }
+
+private:
+    int id;
+    const char* label;
+    UIRect bounds;
+    bool visible;
+    bool enabled;
+    uint16_t bgColor;
+    uint16_t borderColor;
+    uint16_t textColor;
+};
+
+class UITable {
+public:
+    static const uint8_t MAX_ROWS = 6;
+    static const uint8_t MAX_COLS = 3;
+
+    UITable() : rows(0), cols(0), headerBg(TFT_DARKGREY), cellBg(TFT_BLACK), border(TFT_DARKGREY), text(TFT_WHITE) {
+        bounds = {0, 0, 0, 0};
+        for (int r = 0; r < MAX_ROWS; r++) {
+            for (int c = 0; c < MAX_COLS; c++) {
+                cellText[r][c] = "";
+            }
+        }
+    }
+
+    void configure(const UIRect& rect, uint8_t rowCount, uint8_t colCount) {
+        bounds = rect;
+        rows = rowCount > MAX_ROWS ? MAX_ROWS : rowCount;
+        cols = colCount > MAX_COLS ? MAX_COLS : colCount;
+    }
+
+    void setCell(uint8_t row, uint8_t col, const char* value) {
+        if (row < rows && col < cols) {
+            cellText[row][col] = value;
+        }
+    }
+
+    void draw(TFT_eSprite& sprite, bool hasHeader = true) const {
+        if (rows == 0 || cols == 0) {
+            return;
+        }
+
+        int cellW = bounds.w / cols;
+        int cellH = bounds.h / rows;
+
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                int x = bounds.x + (c * cellW);
+                int y = bounds.y + (r * cellH);
+                uint16_t bg = (hasHeader && r == 0) ? headerBg : cellBg;
+                sprite.fillRect(x, y, cellW, cellH, bg);
+                sprite.drawRect(x, y, cellW, cellH, border);
+                sprite.setTextColor(text);
+                sprite.setTextFont(2);
+                sprite.setTextSize(1);
+                int textWidth = sprite.textWidth(cellText[r][c]);
+                int textHeight = sprite.fontHeight();
+                sprite.setCursor(x + (cellW - textWidth) / 2, y + (cellH - textHeight) / 2);
+                sprite.print(cellText[r][c]);
+            }
+        }
+    }
+
+private:
+    UIRect bounds;
+    uint8_t rows;
+    uint8_t cols;
+    const char* cellText[MAX_ROWS][MAX_COLS];
+    uint16_t headerBg;
+    uint16_t cellBg;
+    uint16_t border;
+    uint16_t text;
+};
+
+#endif


### PR DESCRIPTION
### Motivation

- Provide a reusable touch/gesture layer so screens can respond to taps, swipes, long-press and pinch actions without reimplementing detection logic. 
- Offer simple, modular UI primitives so screens can compose buttons and tables instead of redrawing ad-hoc UI blocks per screen.

### Description

- Add `ui_library.h` which provides `UIRect`, `UIButton`, and `UITable` primitives for reusable drawing and hit-testing of common UI elements. 
- Extend `touch.h` to a gesture-capable API by adding `TouchGesture` enum/struct and `touch_getGesture(...)` with detection for `TAP`, `LONG_PRESS`, `SWIPE_*`, and `PINCH_IN/PINCH_OUT`. 
- Refactor `options_screen.h` to use `UIButton`/`UITable` and to accept gestures via `handleTouchGesture(...)`, centralizing button construction, hit testing and table rendering (Bluetooth stats view uses `UITable`).
- Integrate gesture handling into `ESP32OBDGauge.ino` main loop so swipes navigate gauges and reset behavior and pinch opens the options screen while preserving existing tap/long-press behavior.

### Testing

- Ran `git diff --check` to validate there are no whitespace/patch issues and it completed successfully. 
- Attempted `arduino-cli version` to check toolchain availability but the command is not present in this environment (manual/toolchain build was not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bb666ef483239cf3858c1d2f4a4f)