### PR TITLE
Add touch gesture engine and modular UI components; integrate gestures into screens

### DIFF
--- a/ESP32OBDGauge.ino
+++ b/ESP32OBDGauge.ino
@@ -11,6 +11,7 @@
 #include "options_screen.h"
 #include "config.h"
 #include "screen_manager.h"
+#include "ui_touch.h"
 
 bool TESTMODE = false;
 
@@ -38,6 +39,7 @@ unsigned long lastTouchTime = 0;
 bool obdConnected = false;
 OptionsScreen* optionsScreen = nullptr;
 bool inOptionsScreen = false;
+TouchGestureEngine touchGestures;
 
 void setup() {
     Serial.begin(115200);
@@ -248,76 +250,77 @@ void dataFetchingTask(void* parameter) {
 }
 
 void loop() {
-    static bool wasTouched = false;
-    static bool ignoreHeldTouchInOptions = false;
     static bool waitingForReleaseAfterOptions = false;
-    static bool justExitedOptions = false;
     static bool waitingForReleaseAfterQuadrantSelector = false;
-    static unsigned long touchStartTime = 0;
-    const unsigned long LONG_PRESS_THRESHOLD = 1000; // 1 second
-    const unsigned long DEBOUNCE_MS = 200;
+    static bool justExitedOptions = false;
 
-    if (touch_touched()) {
-        if (millis() - lastTouchTime > DEBOUNCE_MS) {
-            lastTouchTime = millis();
-            if (!wasTouched) {
-                wasTouched = true;
-                touchStartTime = millis();
+    TouchSample sample = touch_read_sample();
+    TouchGestureEngine::GestureEvent gesture = touchGestures.update(sample);
 
-                if (inOptionsScreen && !waitingForReleaseAfterOptions) {
-                    ignoreHeldTouchInOptions = false;
+    if (inOptionsScreen) {
+        if (gesture.type != TouchGestureEngine::NONE) {
+            if (!optionsScreen->handleGesture(gesture.type)) {
+                exitOptions();
+                justExitedOptions = true;
+            }
+        }
+
+        if (gesture.type == TouchGestureEngine::TAP && sample.points[0].valid) {
+            if (!optionsScreen->handleTouch(sample.points[0].x, sample.points[0].y)) {
+                exitOptions();
+                justExitedOptions = true;
+            }
+        }
+    } else {
+        if (gesture.type == TouchGestureEngine::LONG_PRESS) {
+            xSemaphoreTake(gaugeMutex, portMAX_DELAY);
+            Gauge* current = screenManager.getCurrentGauge();
+            if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
+                QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
+                qg->openSelectorFromTouch(touch_last_x, touch_last_y);
+                waitingForReleaseAfterQuadrantSelector = true;
+            } else {
+                showOptions();
+                waitingForReleaseAfterOptions = true;
+            }
+            xSemaphoreGive(gaugeMutex);
+        } else if (gesture.type == TouchGestureEngine::PINCH_IN) {
+            showOptions();
+            waitingForReleaseAfterOptions = true;
+        } else if (gesture.type == TouchGestureEngine::PINCH_OUT) {
+            resetGauge();
+        } else if (gesture.type == TouchGestureEngine::SWIPE_LEFT) {
+            switchToNextGauge();
+        } else if (gesture.type == TouchGestureEngine::SWIPE_RIGHT) {
+            switchToPreviousGauge();
+        } else if (gesture.type == TouchGestureEngine::TAP && !justExitedOptions) {
+            bool handledByQuadrantSelector = false;
+            xSemaphoreTake(gaugeMutex, portMAX_DELAY);
+            Gauge* current = screenManager.getCurrentGauge();
+            if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
+                QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
+                if (qg->isSelectorVisible()) {
+                    qg->handleTouch(touch_last_x, touch_last_y);
+                    handledByQuadrantSelector = true;
                 }
             }
+            xSemaphoreGive(gaugeMutex);
 
-            if (inOptionsScreen) {
-                if (!ignoreHeldTouchInOptions) {
-                    if (touch_last_x >= 0 && touch_last_y >= 0) {
-                        if (!optionsScreen->handleTouch(touch_last_x, touch_last_y)) {
-                            exitOptions();
-                            justExitedOptions = true;
-                            Serial.println("Just exited options screen");
-                        }
-                    }
-                }
-            } else {
-                bool handledSelectorTouch = false;
-                xSemaphoreTake(gaugeMutex, portMAX_DELAY);
-                Gauge* current = screenManager.getCurrentGauge();
-                if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
-                    QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
-                    if (qg->isSelectorVisible()) {
-                        if (!waitingForReleaseAfterQuadrantSelector) {
-                            qg->handleTouch(touch_last_x, touch_last_y);
-                        }
-                        handledSelectorTouch = true;
-                    }
-                }
-                xSemaphoreGive(gaugeMutex);
-
-                if (!handledSelectorTouch && millis() - touchStartTime > LONG_PRESS_THRESHOLD) {
-                    xSemaphoreTake(gaugeMutex, portMAX_DELAY);
-                    current = screenManager.getCurrentGauge();
-                    if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
-                        QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
-                        qg->openSelectorFromTouch(touch_last_x, touch_last_y);
-                        waitingForReleaseAfterQuadrantSelector = true;
-                    } else {
-                        showOptions();
-                        ignoreHeldTouchInOptions = true;
-                        waitingForReleaseAfterOptions = true;
-                    }
-                    xSemaphoreGive(gaugeMutex);
-                    wasTouched = true;
+            if (!handledByQuadrantSelector) {
+                if ((touch_last_x >= 0 && touch_last_x <= 40) && (touch_last_y >= 0 && touch_last_y <= 40)) {
+                    Serial.println("Last OBD diagnostic: " + commands.getLastQueryDiagnostic());
+                } else if ((touch_last_x >= 0 && touch_last_x < 30) && (touch_last_y > 210 && touch_last_y <= 240)) {
+                    resetGauge();
+                } else {
+                    switchToNextGauge();
                 }
             }
         }
-    } else if (wasTouched && !touch_touched()) {
-        wasTouched = false;
+    }
 
+    if (!sample.touched) {
         if (waitingForReleaseAfterOptions) {
-            // Now we can allow interaction again
             waitingForReleaseAfterOptions = false;
-            ignoreHeldTouchInOptions = false;
         }
 
         if (waitingForReleaseAfterQuadrantSelector) {
@@ -328,29 +331,6 @@ void loop() {
         if (justExitedOptions) {
             justExitedOptions = false;
             return;
-        }
-
-        if (!inOptionsScreen && millis() - touchStartTime < LONG_PRESS_THRESHOLD) {
-            bool handledByQuadrantSelector = false;
-            xSemaphoreTake(gaugeMutex, portMAX_DELAY);
-            Gauge* current = screenManager.getCurrentGauge();
-            if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
-                QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
-                handledByQuadrantSelector = qg->isSelectorVisible();
-            }
-            xSemaphoreGive(gaugeMutex);
-
-            if (!handledByQuadrantSelector) {
-                if ((touch_last_x >= 0 && touch_last_x <= 40) &&
-                    (touch_last_y >= 0 && touch_last_y <= 40)) {
-                    Serial.println("Last OBD diagnostic: " + commands.getLastQueryDiagnostic());
-                } else if ((touch_last_x >= 0 && touch_last_x < 30) &&
-                           (touch_last_y > 210 && touch_last_y <= 240)) {
-                    resetGauge();
-                } else {
-                    switchToNextGauge();
-                }
-            }
         }
     }
 
@@ -377,21 +357,34 @@ void loop() {
         }
 
         xSemaphoreGive(gaugeMutex);
-        //if (obdConnected) {
-            //display.drawRect(0, 0, 10, 10, TFT_GREEN);
-        //}
-        //else {
-            //display.drawRect(0, 0, 10, 10, TFT_RED);
-        //}
     }
-
-    // Limit to ~200 FPS
-    //delay(250);
 }
 
 void switchToNextGauge() {
     xSemaphoreTake(gaugeMutex, portMAX_DELAY);
     screenManager.moveNext(obdConnected, FALLBACK_GAUGE_INDEX);
+    currentGauge = screenManager.getCurrentGaugeIndex();
+    Gauge* current = screenManager.getCurrentGauge();
+    if (current != nullptr) {
+        current->initialize();
+    }
+
+    updateCurrentGaugeSettings(currentGauge);
+    xSemaphoreGive(gaugeMutex);
+}
+
+void switchToPreviousGauge() {
+    xSemaphoreTake(gaugeMutex, portMAX_DELAY);
+    if (obdConnected) {
+        int prev = screenManager.getCurrentGaugeIndex() - 1;
+        if (prev < 0) {
+            prev = GAUGE_COUNT - 1;
+        }
+        screenManager.setCurrentGauge(prev);
+    } else {
+        screenManager.setCurrentGauge(FALLBACK_GAUGE_INDEX);
+    }
+
     currentGauge = screenManager.getCurrentGaugeIndex();
     Gauge* current = screenManager.getCurrentGauge();
     if (current != nullptr) {

--- a/options_screen.h
+++ b/options_screen.h
@@ -2,387 +2,327 @@
 #define OPTIONS_SCREEN_H
 
 #include <TFT_eSPI.h>
+#include "config.h"
+#include "gauge.h"
+#include "g_meter.h"
+#include "needle_gauge.h"
+#include "dual_gauge.h"
+#include "ui_components.h"
+#include "ui_touch.h"
 
 class OptionsScreen {
 public:
-    OptionsScreen(TFT_eSPI* display, Gauge** gauges, int numGauges) : 
-        display(display), 
-        gauges(gauges), 
-        numGauges(numGauges), 
-        screenSprite(display),
-        state(MAIN_MENU),
-        bluetoothState(MAIN_BLUETOOTH_MENU),
-        colorState(MAIN_COLOR_MENU) {}
+  OptionsScreen(TFT_eSPI* display, Gauge** gauges, int numGauges)
+      : display(display), gauges(gauges), numGauges(numGauges), screenSprite(display), state(MAIN_MENU), colorState(MAIN_COLOR_MENU),
+        bluetoothState(MAIN_BLUETOOTH_MENU) {}
 
-    void initialize() {
-        display->fillScreen(TFT_BLACK);
-        if (!screenSprite.createSprite(DISPLAY_WIDTH, DISPLAY_HEIGHT)) {
-            Serial.println("Failed to create options screen sprite");
-            return;
-        }
-        drawMainMenu();
+  void initialize() {
+    display->fillScreen(TFT_BLACK);
+    if (!screenSprite.createSprite(DISPLAY_WIDTH, DISPLAY_HEIGHT)) {
+      Serial.println("Failed to create options screen sprite");
+      return;
     }
+    drawMainMenu();
+  }
 
-    bool handleTouch(uint16_t x, uint16_t y) {
-        Serial.println(String(state));
-        if (state == MAIN_MENU) {
-            // Check main menu buttons
-            for (int i = 0; i < 2; i++) {
-                for (int j = 0; j < 2; j++) {
-                    int bx = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                    int by = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                    if (x >= bx && x < bx + BUTTON_WIDTH && y >= by && y < by + BUTTON_HEIGHT) {
-                        if (i == 0 && j == 0) { // G-meter calibration
-                            state = ABOUT;
-                            drawAboutMenu();
-                            return true;
-                        } else if (i == 0 && j == 1) { // Bluetooth settings
-                            state = BLUETOOTH;
-                            drawBluetoothMenu();
-                            return true;
-                        } else if (i == 1 && j == 0) { // Color settings
-                            state = COLOR;
-                            drawColorMenu();
-                            return true;
-                        } else if (i == 1 && j == 1) { // Exit
-                            return false;
-                        }
-                    }
-                }
-            }
-            return true; // No button touched so dont process any input or change screens
-        } else if (state == ABOUT) {
-            return handleAboutTouch(x, y);
-        } else if (state == BLUETOOTH) {
-            return handleBluetoothTouch(x, y);
-        } else if (state == COLOR) {
-            return handleColorTouch(x, y);
-        }
+  bool handleTouch(uint16_t x, uint16_t y) {
+    switch (state) {
+      case MAIN_MENU:
+        return handleMainMenuTap(x, y);
+      case ABOUT:
+        return handleAboutTap(x, y);
+      case BLUETOOTH:
+        return handleBluetoothTap(x, y);
+      case COLOR:
+        return handleColorTap(x, y);
+    }
+    return true;
+  }
+
+  bool handleGesture(TouchGestureEngine::GestureType gesture) {
+    if (gesture == TouchGestureEngine::SWIPE_RIGHT || gesture == TouchGestureEngine::SWIPE_DOWN) {
+      if (state == MAIN_MENU) {
+        return false;
+      }
+      if (state == COLOR && colorState != MAIN_COLOR_MENU) {
+        colorState = MAIN_COLOR_MENU;
+        drawColorMenu();
         return true;
+      }
+      if (state == BLUETOOTH && bluetoothState != MAIN_BLUETOOTH_MENU) {
+        bluetoothState = MAIN_BLUETOOTH_MENU;
+        drawBluetoothMenu();
+        return true;
+      }
+      state = MAIN_MENU;
+      drawMainMenu();
+      return true;
     }
+    return true;
+  }
 
 private:
-    TFT_eSPI* display;
-    Gauge** gauges;
-    int numGauges;
-    TFT_eSprite screenSprite;
-    
-    enum ScreenState { MAIN_MENU, ABOUT, BLUETOOTH, COLOR };
-    enum BluetoothState { MAIN_BLUETOOTH_MENU, PAIRING_MENU, STATS_MENU };
-    enum ColorState { MAIN_COLOR_MENU, NEEDLE_COLOR, OUTLINE_COLOR, VALUE_COLOR };
-    ScreenState state;
-    BluetoothState bluetoothState;
-    ColorState colorState;
+  enum ScreenState { MAIN_MENU, ABOUT, BLUETOOTH, COLOR };
+  enum ColorState { MAIN_COLOR_MENU, NEEDLE_COLOR, OUTLINE_COLOR, VALUE_COLOR };
+  enum BluetoothState { MAIN_BLUETOOTH_MENU, STATS_MENU };
 
-    // Button dimensions
-    static const int BUTTON_WIDTH = 140;
-    static const int BUTTON_HEIGHT = 100;
-    static const int BUTTON_SPACING = 20;
-    static const int BUTTON_MARGIN = 10;
-    static const int COLOR_SWATCH_SIZE = 60;
+  TFT_eSPI* display;
+  Gauge** gauges;
+  int numGauges;
+  TFT_eSprite screenSprite;
+  ScreenState state;
+  ColorState colorState;
+  BluetoothState bluetoothState;
 
-    // Color options
-    uint16_t colorOptions[12] = {
-        TFT_RED, TFT_GREEN, TFT_BLUE, TFT_YELLOW,
-        TFT_ORANGE, TFT_DARKGREEN, TFT_CYAN, TFT_GOLD, 
-        TFT_VIOLET, TFT_PURPLE, TFT_SILVER, TFT_WHITE
-    };
+  static const int BUTTON_MARGIN = 10;
+  static const int BUTTON_SPACING = 20;
+  static const int COLOR_SWATCH_SIZE = 60;
 
-    bool handleAboutTouch(uint16_t x, uint16_t y) {
-        int buttonWidth = 190;
-        int buttonHeight = 55;
-        int calibrateX = (DISPLAY_WIDTH - buttonWidth) / 2;
-        int calibrateY = 90;
-        int backX = calibrateX;
-        int backY = 160;
+  uint16_t colorOptions[12] = {TFT_RED, TFT_GREEN, TFT_BLUE, TFT_YELLOW, TFT_ORANGE, TFT_DARKGREEN,
+                               TFT_CYAN, TFT_GOLD, TFT_VIOLET, TFT_PURPLE, TFT_SILVER, TFT_WHITE};
 
-        if (x >= calibrateX && x < calibrateX + buttonWidth && y >= calibrateY && y < calibrateY + buttonHeight) {
-            triggerGMeterCalibration();
-            drawAboutMenu();
-            return true;
-        }
+  bool handleMainMenuTap(uint16_t x, uint16_t y) {
+    UIButtonGrid grid;
+    grid.configure({BUTTON_MARGIN, BUTTON_MARGIN, DISPLAY_WIDTH - (2 * BUTTON_MARGIN), DISPLAY_HEIGHT - (2 * BUTTON_MARGIN)}, 2, 2, BUTTON_SPACING);
+    int8_t index = grid.hitTest(x, y);
 
-        if (x >= backX && x < backX + buttonWidth && y >= backY && y < backY + buttonHeight) {
-            state = MAIN_MENU;
-            drawMainMenu();
-            return true;
-        }
+    if (index == 0) {
+      state = ABOUT;
+      drawAboutMenu();
+      return true;
+    }
+    if (index == 1) {
+      state = BLUETOOTH;
+      bluetoothState = MAIN_BLUETOOTH_MENU;
+      drawBluetoothMenu();
+      return true;
+    }
+    if (index == 2) {
+      state = COLOR;
+      colorState = MAIN_COLOR_MENU;
+      drawColorMenu();
+      return true;
+    }
+    if (index == 3) {
+      return false;
+    }
+    return true;
+  }
 
-        return true;
+  bool handleAboutTap(uint16_t x, uint16_t y) {
+    UIButton calibrate({65, 90, 190, 55}, "Start Calibration", TFT_DARKGREEN);
+    UIButton back({65, 160, 190, 55}, "Back", TFT_DARKGREY);
+
+    if (calibrate.hitTest(x, y)) {
+      triggerGMeterCalibration();
+      drawAboutMenu();
+    } else if (back.hitTest(x, y)) {
+      state = MAIN_MENU;
+      drawMainMenu();
+    }
+    return true;
+  }
+
+  bool handleBluetoothTap(uint16_t x, uint16_t y) {
+    if (bluetoothState == STATS_MENU) {
+      UIButton back({65, 185, 190, 45}, "Back", TFT_DARKGREY);
+      if (back.hitTest(x, y)) {
+        bluetoothState = MAIN_BLUETOOTH_MENU;
+        drawBluetoothMenu();
+      }
+      return true;
     }
 
-    bool handleColorTouch(uint16_t x, uint16_t y) {
-        if (colorState == MAIN_COLOR_MENU) {
-            // Check main menu buttons
-            for (int i = 0; i < 2; i++) {
-                for (int j = 0; j < 2; j++) {
-                    int bx = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                    int by = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                    if (x >= bx && x < bx + BUTTON_WIDTH && y >= by && y < by + BUTTON_HEIGHT) {
-                        if (i == 0 && j == 0) { // Needle color
-                            colorState = NEEDLE_COLOR;
-                            drawColorPicker();  
-                            return true;
-                        } else if (i == 0 && j == 1) { // Outline color
-                            colorState = OUTLINE_COLOR;
-                            drawColorPicker();
-                            return true;
-                        } else if (i == 1 && j == 0) { // Value color
-                            colorState = VALUE_COLOR;
-                            drawColorPicker();
-                            return true;
-                        } else if (i == 1 && j == 1) { // Exit
-                            colorState = MAIN_COLOR_MENU;
-                            state = MAIN_MENU;
-                            drawMainMenu();
-                            return true;
-                        }
-                    }
-                }
-            }
-            return true; // No button touched so dont process any input or change screens
-        } else {
-            // Not in main menu, only one sub menu to set color, so check color swatches
-            for (int i = 0; i < 3; i++) {
-                for (int j = 0; j < 4; j++) {
-                    int cx = BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                    int cy = BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                    if (x >= cx && x < cx + COLOR_SWATCH_SIZE && y >= cy && y < cy + COLOR_SWATCH_SIZE) {
-                        // Handle color update based on screen state
-                        uint16_t color = colorOptions[i * 4 + j];
-                        switch (colorState) {
-                            case NEEDLE_COLOR:
-                                updateNeedleColor(color);
-                                break;
-                            case OUTLINE_COLOR:
-                                updateOutlineColor(color);
-                                break;
-                            case VALUE_COLOR:
-                                updateValueColor(color);
-                                break;
-                            default:
-                                break;
-                        }
+    UIButtonGrid grid;
+    grid.configure({BUTTON_MARGIN, BUTTON_MARGIN, DISPLAY_WIDTH - (2 * BUTTON_MARGIN), DISPLAY_HEIGHT - (2 * BUTTON_MARGIN)}, 2, 2, BUTTON_SPACING);
+    int8_t index = grid.hitTest(x, y);
 
-                        // Return to the main color menu
-                        colorState = MAIN_COLOR_MENU;
-                        drawColorMenu();
-                        return true;
-                    }
-                }
-            }
-            return true; // No button touched so dont process any input or change screens
+    if (index == 0) {
+      drawBluetoothMessage("Pairing managed by\nOBD connection flow");
+    } else if (index == 1) {
+      bluetoothState = STATS_MENU;
+      drawBluetoothStats();
+    } else if (index == 2) {
+      drawBluetoothMessage("Remove not implemented");
+    } else if (index == 3) {
+      state = MAIN_MENU;
+      drawMainMenu();
+    }
+    return true;
+  }
+
+  bool handleColorTap(uint16_t x, uint16_t y) {
+    if (colorState == MAIN_COLOR_MENU) {
+      UIButtonGrid grid;
+      grid.configure({BUTTON_MARGIN, BUTTON_MARGIN, DISPLAY_WIDTH - (2 * BUTTON_MARGIN), DISPLAY_HEIGHT - (2 * BUTTON_MARGIN)}, 2, 2, BUTTON_SPACING);
+      int8_t index = grid.hitTest(x, y);
+
+      if (index == 0) {
+        colorState = NEEDLE_COLOR;
+        drawColorPicker();
+      } else if (index == 1) {
+        colorState = OUTLINE_COLOR;
+        drawColorPicker();
+      } else if (index == 2) {
+        colorState = VALUE_COLOR;
+        drawColorPicker();
+      } else if (index == 3) {
+        state = MAIN_MENU;
+        drawMainMenu();
+      }
+      return true;
+    }
+
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 4; j++) {
+        UIRect swatch = {BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING), BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING), COLOR_SWATCH_SIZE,
+                         COLOR_SWATCH_SIZE};
+        if (swatch.contains(x, y)) {
+          uint16_t selectedColor = colorOptions[i * 4 + j];
+          if (colorState == NEEDLE_COLOR)
+            updateNeedleColor(selectedColor);
+          else if (colorState == OUTLINE_COLOR)
+            updateOutlineColor(selectedColor);
+          else
+            updateValueColor(selectedColor);
+
+          colorState = MAIN_COLOR_MENU;
+          drawColorMenu();
+          return true;
         }
+      }
     }
 
-    bool handleBluetoothTouch(uint16_t x, uint16_t y) {
-        // Check main menu buttons
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int bx = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int by = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                if (x >= bx && x < bx + BUTTON_WIDTH && y >= by && y < by + BUTTON_HEIGHT) {
-                    if (i == 0 && j == 0) { // Pair device
-                        // To be implemented
-                    } else if (i == 0 && j == 1) { // Delete device
-                        
-                    } else if (i == 1 && j == 0) { // Stats
-                        
-                    } else if (i == 1 && j == 1) { // Exit
-                        state = MAIN_MENU;
-                        drawMainMenu();
-                        return true;
-                    }
-                }
-            }
-        }
-        return true; // No button touched so dont process any input or change screens
+    return true;
+  }
+
+  void drawMainMenu() {
+    screenSprite.fillSprite(TFT_BLACK);
+    UIButtonGrid grid;
+    grid.configure({BUTTON_MARGIN, BUTTON_MARGIN, DISPLAY_WIDTH - (2 * BUTTON_MARGIN), DISPLAY_HEIGHT - (2 * BUTTON_MARGIN)}, 2, 2, BUTTON_SPACING);
+    grid.setButton(0, "G-Meter", TFT_DARKGREEN);
+    grid.setButton(1, "Bluetooth");
+    grid.setButton(2, "Colors");
+    grid.setButton(3, "Exit");
+    grid.draw(screenSprite);
+    screenSprite.pushSprite(0, 0);
+  }
+
+  void drawAboutMenu() {
+    screenSprite.fillSprite(TFT_BLACK);
+    screenSprite.setTextFont(2);
+    screenSprite.setTextSize(2);
+    screenSprite.setTextColor(TFT_WHITE);
+    screenSprite.setCursor(60, 24);
+    screenSprite.print("G-Meter Calibration");
+    screenSprite.setTextSize(1);
+    screenSprite.setCursor(35, 55);
+    screenSprite.print("Park on flat ground before calibrating.");
+
+    UIButton({65, 90, 190, 55}, "Start Calibration", TFT_DARKGREEN).draw(screenSprite);
+    UIButton({65, 160, 190, 55}, "Back", TFT_DARKGREY).draw(screenSprite);
+    screenSprite.pushSprite(0, 0);
+  }
+
+  void drawBluetoothMenu() {
+    screenSprite.fillSprite(TFT_BLACK);
+    UIButtonGrid grid;
+    grid.configure({BUTTON_MARGIN, BUTTON_MARGIN, DISPLAY_WIDTH - (2 * BUTTON_MARGIN), DISPLAY_HEIGHT - (2 * BUTTON_MARGIN)}, 2, 2, BUTTON_SPACING);
+    grid.setButton(0, "Pair Device");
+    grid.setButton(1, "Stats", TFT_DARKGREEN);
+    grid.setButton(2, "Remove", TFT_MAROON);
+    grid.setButton(3, "Exit");
+    grid.draw(screenSprite);
+    screenSprite.pushSprite(0, 0);
+  }
+
+  void drawBluetoothStats() {
+    screenSprite.fillSprite(TFT_BLACK);
+    UITable table;
+    table.setBounds({20, 20, DISPLAY_WIDTH - 40, 150});
+    table.setHeader("Bluetooth Status", TFT_NAVY);
+    table.addRow("Screen", "Options");
+    table.addRow("Connected", "Managed globally");
+    table.addRow("Action", "Swipe right to back");
+    table.addRow("Version", SOFTWARE_VERSION);
+    table.draw(screenSprite);
+    UIButton({65, 185, 190, 45}, "Back", TFT_DARKGREY).draw(screenSprite);
+    screenSprite.pushSprite(0, 0);
+  }
+
+  void drawBluetoothMessage(const char* message) {
+    screenSprite.fillSprite(TFT_BLACK);
+    screenSprite.setTextFont(2);
+    screenSprite.setTextSize(1);
+    screenSprite.setTextColor(TFT_WHITE);
+    screenSprite.setCursor(25, 70);
+    screenSprite.print(message);
+    screenSprite.setCursor(25, 100);
+    screenSprite.print("Tap anywhere to continue");
+    screenSprite.pushSprite(0, 0);
+    delay(500);
+    drawBluetoothMenu();
+  }
+
+  void drawColorMenu() {
+    screenSprite.fillSprite(TFT_BLACK);
+    UIButtonGrid grid;
+    grid.configure({BUTTON_MARGIN, BUTTON_MARGIN, DISPLAY_WIDTH - (2 * BUTTON_MARGIN), DISPLAY_HEIGHT - (2 * BUTTON_MARGIN)}, 2, 2, BUTTON_SPACING);
+    grid.setButton(0, "Needle", TFT_DARKGREEN);
+    grid.setButton(1, "Outline", TFT_NAVY);
+    grid.setButton(2, "Value", TFT_PURPLE);
+    grid.setButton(3, "Exit");
+    grid.draw(screenSprite);
+    screenSprite.pushSprite(0, 0);
+  }
+
+  void drawColorPicker() {
+    screenSprite.fillSprite(TFT_BLACK);
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 4; j++) {
+        int x = BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
+        int y = BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
+        screenSprite.fillRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, colorOptions[i * 4 + j]);
+        screenSprite.drawRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, TFT_WHITE);
+      }
     }
+    screenSprite.setTextColor(TFT_WHITE);
+    screenSprite.setTextSize(1);
+    screenSprite.setTextFont(2);
+    screenSprite.setCursor(15, 220);
+    screenSprite.print("Select a color or swipe right to return");
+    screenSprite.pushSprite(0, 0);
+  }
 
-    void drawMainMenu() {
-        screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 2x2 grid of buttons
-        const char* labels[2][2] = {
-            {"G-Meter", "Bluetooth"},
-            {"Color", "Exit"}
-        };
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int x = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
-                screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
-            }
-        }
-        screenSprite.pushSprite(0, 0);
+  void triggerGMeterCalibration() {
+    for (int i = 0; i < numGauges; i++) {
+      if (gauges[i]->getType() == Gauge::G_METER) {
+        static_cast<GMeter*>(gauges[i])->beginManualCalibration();
+        break;
+      }
     }
+  }
 
-    void drawAboutMenu() {
-        screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(2);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        String title = "G-Meter Calibration";
-        int titleWidth = screenSprite.textWidth(title);
-        int x = DISPLAY_CENTER_X - (titleWidth / 2);
-        screenSprite.setCursor(x, 24);
-        screenSprite.print(title);
-
-        screenSprite.setTextSize(1);
-        String text = "Park on flat ground before calibrating.";
-        int textWidth = screenSprite.textWidth(text);
-        x = DISPLAY_CENTER_X - (textWidth / 2);
-        screenSprite.setCursor(x, 55);
-        screenSprite.print(text);
-
-        int buttonWidth = 190;
-        int buttonHeight = 55;
-        int buttonX = (DISPLAY_WIDTH - buttonWidth) / 2;
-
-        screenSprite.fillRect(buttonX, 90, buttonWidth, buttonHeight, TFT_DARKGREEN);
-        screenSprite.drawRect(buttonX, 90, buttonWidth, buttonHeight, TFT_WHITE);
-        String calibrate = "Start Calibration";
-        int calibrateWidth = screenSprite.textWidth(calibrate);
-        int calibrateHeight = screenSprite.fontHeight();
-        screenSprite.setCursor(buttonX + (buttonWidth - calibrateWidth) / 2, 90 + (buttonHeight - calibrateHeight) / 2);
-        screenSprite.print(calibrate);
-
-        screenSprite.fillRect(buttonX, 160, buttonWidth, buttonHeight, TFT_DARKGREY);
-        screenSprite.drawRect(buttonX, 160, buttonWidth, buttonHeight, TFT_WHITE);
-        String back = "Back";
-        int backWidth = screenSprite.textWidth(back);
-        int backHeight = screenSprite.fontHeight();
-        screenSprite.setCursor(buttonX + (buttonWidth - backWidth) / 2, 160 + (buttonHeight - backHeight) / 2);
-        screenSprite.print(back);
-
-        screenSprite.pushSprite(0, 0);
+  void updateNeedleColor(uint16_t color) {
+    for (int i = 0; i < numGauges; i++) {
+      if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) static_cast<NeedleGauge*>(gauges[i])->setNeedleColor(color);
+      if (gauges[i]->getType() == Gauge::DUAL_GAUGE) static_cast<DualGauge*>(gauges[i])->setNeedleColor(color);
     }
+  }
 
-    void drawBluetoothMenu() {
-        screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 2x2 grid of buttons
-        const char* labels[2][2] = {
-            {"Pair Device", "Stats"},
-            {"Remove Device", "Exit"}
-        };
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int x = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
-                screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
-            }
-        }
-        screenSprite.pushSprite(0, 0);
+  void updateOutlineColor(uint16_t color) {
+    for (int i = 0; i < numGauges; i++) {
+      if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) static_cast<NeedleGauge*>(gauges[i])->setOutlineColor(color);
+      if (gauges[i]->getType() == Gauge::DUAL_GAUGE) static_cast<DualGauge*>(gauges[i])->setOutlineColor(color);
     }
+  }
 
-    void drawColorMenu() {
-        screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 2x2 grid of buttons
-        const char* labels[2][2] = {
-            {"Needle Color", "Outline Color"},
-            {"Value Color", "Exit"}
-        };
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 2; j++) {
-                int x = BUTTON_MARGIN + j * (BUTTON_WIDTH + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (BUTTON_HEIGHT + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_DARKGREY);
-                screenSprite.drawRect(x, y, BUTTON_WIDTH, BUTTON_HEIGHT, TFT_WHITE);
-                int textWidth = screenSprite.textWidth(labels[i][j]);
-                int textHeight = screenSprite.fontHeight();
-                screenSprite.setCursor(x + (BUTTON_WIDTH - textWidth) / 2, y + (BUTTON_HEIGHT - textHeight) / 2);
-                screenSprite.print(labels[i][j]);
-            }
-        }
-        screenSprite.pushSprite(0, 0);
+  void updateValueColor(uint16_t color) {
+    for (int i = 0; i < numGauges; i++) {
+      if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) static_cast<NeedleGauge*>(gauges[i])->setValueColor(color);
+      if (gauges[i]->getType() == Gauge::DUAL_GAUGE) static_cast<DualGauge*>(gauges[i])->setValueColor(color);
     }
-
-
-    void triggerGMeterCalibration() {
-        for (int i = 0; i < numGauges; i++) {
-            if (gauges[i]->getType() == Gauge::G_METER) {
-                static_cast<GMeter*>(gauges[i])->beginManualCalibration();
-                break;
-            }
-        }
-    }
-
-    void drawColorPicker() {
-        screenSprite.fillSprite(TFT_BLACK);
-        screenSprite.setTextFont(2);
-        screenSprite.setTextSize(1);
-        screenSprite.setTextColor(TFT_WHITE);
-
-        // Draw 4x3 grid of color swatches
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 4; j++) {
-                int x = BUTTON_MARGIN + j * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                int y = BUTTON_MARGIN + i * (COLOR_SWATCH_SIZE + BUTTON_SPACING);
-                screenSprite.fillRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, colorOptions[i * 4 + j]);
-                screenSprite.drawRect(x, y, COLOR_SWATCH_SIZE, COLOR_SWATCH_SIZE, TFT_WHITE);
-            }
-        }
-
-        screenSprite.pushSprite(0, 0);
-    }
-
-    void updateNeedleColor(uint16_t color) {
-        for (int i = 0; i < numGauges; i++) {
-            if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) {
-                static_cast<NeedleGauge*>(gauges[i])->setNeedleColor(color);
-            }
-
-            if (gauges[i]->getType() == Gauge::DUAL_GAUGE) {
-                static_cast<DualGauge*>(gauges[i])->setNeedleColor(color);
-            }
-        }
-    }
-
-    void updateOutlineColor(uint16_t color) {
-        for (int i = 0; i < numGauges; i++) {
-            if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) {
-                static_cast<NeedleGauge*>(gauges[i])->setOutlineColor(color);
-            }
- 
-            if (gauges[i]->getType() == Gauge::DUAL_GAUGE) {
-                static_cast<DualGauge*>(gauges[i])->setOutlineColor(color);
-            }
-        }
-    }
-
-    void updateValueColor(uint16_t color) {
-        for (int i = 0; i < numGauges; i++) {
-            if (gauges[i]->getType() == Gauge::NEEDLE_GAUGE) {
-                static_cast<NeedleGauge*>(gauges[i])->setValueColor(color);
-            }
-
-            if (gauges[i]->getType() == Gauge::DUAL_GAUGE) {
-                static_cast<DualGauge*>(gauges[i])->setValueColor(color);
-            }            
-        }
-    }
+  }
 };
 
 #endif

--- a/touch.h
+++ b/touch.h
@@ -1,25 +1,51 @@
+#ifndef TOUCH_H
+#define TOUCH_H
+
 #include <FT6336.h>
 
- #define TOUCH_FT6336
- #define TOUCH_FT6336_SCL 22
- #define TOUCH_FT6336_SDA 21
- #define TOUCH_FT6336_INT 15
- #define TOUCH_FT6336_RST 13
- #define TOUCH_MAP_X1 0
- #define TOUCH_MAP_X2 240
- #define TOUCH_MAP_Y1 0
- #define TOUCH_MAP_Y2 320
+#define TOUCH_FT6336
+#define TOUCH_FT6336_SCL 22
+#define TOUCH_FT6336_SDA 21
+#define TOUCH_FT6336_INT 15
+#define TOUCH_FT6336_RST 13
+#define TOUCH_MAP_X1 0
+#define TOUCH_MAP_X2 240
+#define TOUCH_MAP_Y1 0
+#define TOUCH_MAP_Y2 320
+
+struct TouchPoint {
+  uint16_t x;
+  uint16_t y;
+  bool valid;
+};
+
+struct TouchSample {
+  bool touched;
+  uint8_t pointCount;
+  TouchPoint points[2];
+  uint32_t timestamp;
+};
 
 int touch_last_x = 0, touch_last_y = 0;
-unsigned short int width=0, height=0, rotation,min_x=0,max_x=0,min_y=0,max_y=0;
+unsigned short int width = 0, height = 0, rotation, min_x = 0, max_x = 0, min_y = 0, max_y = 0;
 
-FT6336 ts = FT6336(TOUCH_FT6336_SDA, TOUCH_FT6336_SCL, TOUCH_FT6336_INT, TOUCH_FT6336_RST, max(TOUCH_MAP_X1, TOUCH_MAP_X2), max(TOUCH_MAP_Y1, TOUCH_MAP_Y2));
+FT6336 ts = FT6336(TOUCH_FT6336_SDA, TOUCH_FT6336_SCL, TOUCH_FT6336_INT, TOUCH_FT6336_RST,
+                   max(TOUCH_MAP_X1, TOUCH_MAP_X2), max(TOUCH_MAP_Y1, TOUCH_MAP_Y2));
 
-void touch_init(unsigned short int w, unsigned short int h,unsigned char r)
-{
-  width = w; 
+static inline uint16_t mapTouchX(uint16_t rawX) {
+  return map(rawX, min_x, max_x, 0, width - 1);
+}
+
+static inline uint16_t mapTouchY(uint16_t rawY) {
+  return map(rawY, min_y, max_y, 0, height - 1);
+}
+
+void touch_init(unsigned short int w, unsigned short int h, unsigned char r) {
+  width = w;
   height = h;
-  switch (r){
+  rotation = r;
+
+  switch (r) {
     case ROTATION_NORMAL:
     case ROTATION_INVERTED:
       min_x = TOUCH_MAP_X1;
@@ -37,41 +63,68 @@ void touch_init(unsigned short int w, unsigned short int h,unsigned char r)
     default:
       break;
   }
+
   ts.begin();
   ts.setRotation(r);
 }
 
-bool touch_touched(void)
-{
+TouchSample touch_read_sample(void) {
+  TouchSample sample;
+  sample.touched = false;
+  sample.pointCount = 0;
+  sample.timestamp = millis();
+  sample.points[0] = {0, 0, false};
+  sample.points[1] = {0, 0, false};
+
   ts.read();
-  if (ts.isTouched)
-  {
-    touch_last_x = map(ts.points[0].x, min_x, max_x, 0, width - 1);
-    touch_last_y = map(ts.points[0].y, min_y, max_y, 0, height - 1);
-    Serial.printf("Touched at x: %.1d. y: %.1d\n", touch_last_x, touch_last_y);
-    return true;
+
+  if (!ts.isTouched) {
+    return sample;
   }
-  else
-  {
-    return false;
+
+  sample.touched = true;
+
+  // Primary point is always available when touched.
+  sample.points[0].x = mapTouchX(ts.points[0].x);
+  sample.points[0].y = mapTouchY(ts.points[0].y);
+  sample.points[0].valid = true;
+  sample.pointCount = 1;
+
+  touch_last_x = sample.points[0].x;
+  touch_last_y = sample.points[0].y;
+
+  // FT6336 supports up to two points. Treat a non-zero secondary point as valid.
+  if (ts.points[1].x != 0 || ts.points[1].y != 0) {
+    sample.points[1].x = mapTouchX(ts.points[1].x);
+    sample.points[1].y = mapTouchY(ts.points[1].y);
+    sample.points[1].valid = true;
+    sample.pointCount = 2;
   }
+
+  return sample;
+}
+
+bool touch_touched(void) {
+  TouchSample sample = touch_read_sample();
+  return sample.touched;
 }
 
 bool touch_getXY(uint16_t* x, uint16_t* y) {
-    if (touch_touched()) {
-        *x = touch_last_x;
-        *y = touch_last_y;
-        return true;
-    }
-    return false;
+  TouchSample sample = touch_read_sample();
+  if (sample.touched && sample.points[0].valid) {
+    *x = sample.points[0].x;
+    *y = sample.points[0].y;
+    return true;
+  }
+  return false;
 }
 
-bool touch_has_signal(void)
-{
+bool touch_has_signal(void) {
   return true;
 }
 
-bool touch_released(void)
-{
+bool touch_released(void) {
   return true;
 }
+
+#endif

--- a/ui_components.h
+++ b/ui_components.h
@@ -1,0 +1,161 @@
+#ifndef UI_COMPONENTS_H
+#define UI_COMPONENTS_H
+
+#include <TFT_eSPI.h>
+#include <string.h>
+
+struct UIRect {
+  int16_t x;
+  int16_t y;
+  int16_t w;
+  int16_t h;
+
+  bool contains(uint16_t px, uint16_t py) const {
+    return px >= x && px < (x + w) && py >= y && py < (y + h);
+  }
+};
+
+class UIButton {
+public:
+  UIButton() : label(""), textColor(TFT_WHITE), bgColor(TFT_DARKGREY), borderColor(TFT_WHITE), bounds({0, 0, 0, 0}) {}
+  UIButton(UIRect rect, const char* text, uint16_t background, uint16_t border = TFT_WHITE, uint16_t textClr = TFT_WHITE)
+      : label(text), textColor(textClr), bgColor(background), borderColor(border), bounds(rect) {}
+
+  void setBounds(const UIRect& rect) { bounds = rect; }
+  void setLabel(const char* text) { label = text; }
+  void setColors(uint16_t background, uint16_t border = TFT_WHITE, uint16_t textClr = TFT_WHITE) {
+    bgColor = background;
+    borderColor = border;
+    textColor = textClr;
+  }
+
+  bool hitTest(uint16_t x, uint16_t y) const { return bounds.contains(x, y); }
+
+  void draw(TFT_eSprite& sprite, uint8_t font = 2, uint8_t textSize = 1) const {
+    sprite.fillRect(bounds.x, bounds.y, bounds.w, bounds.h, bgColor);
+    sprite.drawRect(bounds.x, bounds.y, bounds.w, bounds.h, borderColor);
+    sprite.setTextFont(font);
+    sprite.setTextSize(textSize);
+    sprite.setTextColor(textColor);
+    int16_t tw = sprite.textWidth(label);
+    int16_t th = sprite.fontHeight();
+    sprite.setCursor(bounds.x + (bounds.w - tw) / 2, bounds.y + (bounds.h - th) / 2);
+    sprite.print(label);
+  }
+
+private:
+  const char* label;
+  uint16_t textColor;
+  uint16_t bgColor;
+  uint16_t borderColor;
+  UIRect bounds;
+};
+
+class UIButtonGrid {
+public:
+  static const uint8_t MAX_ITEMS = 8;
+
+  UIButtonGrid() : count(0) {}
+
+  void configure(UIRect container, uint8_t columns, uint8_t rows, int16_t spacing) {
+    if (columns == 0 || rows == 0) return;
+
+    const int16_t cellW = (container.w - ((columns - 1) * spacing)) / columns;
+    const int16_t cellH = (container.h - ((rows - 1) * spacing)) / rows;
+
+    count = 0;
+    for (uint8_t r = 0; r < rows; r++) {
+      for (uint8_t c = 0; c < columns; c++) {
+        if (count >= MAX_ITEMS) return;
+        bounds[count] = {(int16_t)(container.x + c * (cellW + spacing)),
+                         (int16_t)(container.y + r * (cellH + spacing)),
+                         cellW,
+                         cellH};
+        buttons[count].setBounds(bounds[count]);
+        buttons[count].setColors(TFT_DARKGREY);
+        count++;
+      }
+    }
+  }
+
+  void setButton(uint8_t index, const char* label, uint16_t bgColor = TFT_DARKGREY) {
+    if (index >= count) return;
+    buttons[index].setBounds(bounds[index]);
+    buttons[index].setLabel(label);
+    buttons[index].setColors(bgColor);
+  }
+
+  int8_t hitTest(uint16_t x, uint16_t y) const {
+    for (uint8_t i = 0; i < count; i++) {
+      if (buttons[i].hitTest(x, y)) return (int8_t)i;
+    }
+    return -1;
+  }
+
+  void draw(TFT_eSprite& sprite) const {
+    for (uint8_t i = 0; i < count; i++) buttons[i].draw(sprite);
+  }
+
+private:
+  UIButton buttons[MAX_ITEMS];
+  UIRect bounds[MAX_ITEMS];
+  uint8_t count;
+};
+
+class UITable {
+public:
+  static const uint8_t MAX_ROWS = 10;
+
+  UITable() : rowCount(0), rowHeight(22), bounds({0, 0, 0, 0}), headerColor(TFT_DARKGREY) { header[0] = '\0'; }
+
+  void setBounds(const UIRect& rect) { bounds = rect; }
+  void setHeader(const char* text, uint16_t color = TFT_DARKGREY) {
+    strncpy(header, text, sizeof(header) - 1);
+    header[sizeof(header) - 1] = '\0';
+    headerColor = color;
+  }
+  void clearRows() { rowCount = 0; }
+
+  void addRow(const char* key, const char* value) {
+    if (rowCount >= MAX_ROWS) return;
+    strncpy(rows[rowCount].key, key, sizeof(rows[rowCount].key) - 1);
+    rows[rowCount].key[sizeof(rows[rowCount].key) - 1] = '\0';
+    strncpy(rows[rowCount].value, value, sizeof(rows[rowCount].value) - 1);
+    rows[rowCount].value[sizeof(rows[rowCount].value) - 1] = '\0';
+    rowCount++;
+  }
+
+  void draw(TFT_eSprite& sprite) const {
+    sprite.drawRect(bounds.x, bounds.y, bounds.w, bounds.h, TFT_WHITE);
+    sprite.fillRect(bounds.x, bounds.y, bounds.w, rowHeight, headerColor);
+    sprite.setTextFont(2);
+    sprite.setTextSize(1);
+    sprite.setTextColor(TFT_WHITE);
+    sprite.setCursor(bounds.x + 6, bounds.y + 4);
+    sprite.print(header);
+
+    for (uint8_t i = 0; i < rowCount; i++) {
+      int16_t rowY = bounds.y + rowHeight + (i * rowHeight);
+      if (rowY + rowHeight > bounds.y + bounds.h) break;
+      sprite.drawLine(bounds.x, rowY, bounds.x + bounds.w, rowY, TFT_DARKGREY);
+      sprite.setTextColor(TFT_CYAN);
+      sprite.setCursor(bounds.x + 6, rowY + 4);
+      sprite.print(rows[i].key);
+      sprite.setTextColor(TFT_WHITE);
+      sprite.setCursor(bounds.x + (bounds.w / 2), rowY + 4);
+      sprite.print(rows[i].value);
+    }
+  }
+
+private:
+  struct TableRow { char key[18]; char value[22]; };
+
+  TableRow rows[MAX_ROWS];
+  uint8_t rowCount;
+  int16_t rowHeight;
+  UIRect bounds;
+  char header[24];
+  uint16_t headerColor;
+};
+
+#endif

--- a/ui_touch.h
+++ b/ui_touch.h
@@ -1,0 +1,157 @@
+#ifndef UI_TOUCH_H
+#define UI_TOUCH_H
+
+#include "touch.h"
+#include <math.h>
+
+class TouchGestureEngine {
+public:
+  enum GestureType {
+    NONE,
+    TAP,
+    LONG_PRESS,
+    SWIPE_LEFT,
+    SWIPE_RIGHT,
+    SWIPE_UP,
+    SWIPE_DOWN,
+    PINCH_IN,
+    PINCH_OUT
+  };
+
+  struct GestureEvent {
+    GestureType type;
+    TouchSample sample;
+  };
+
+  TouchGestureEngine()
+      : isTouchDown(false),
+        touchStartMs(0),
+        startX(0),
+        startY(0),
+        lastX(0),
+        lastY(0),
+        hasPinchStart(false),
+        pinchStartDistance(0.0f),
+        pinchCooldownUntil(0),
+        longPressFired(false) {}
+
+  GestureEvent update(const TouchSample& sample) {
+    GestureEvent event = {NONE, sample};
+
+    if (sample.touched && sample.pointCount > 0) {
+      if (!isTouchDown) {
+        beginTouch(sample);
+      }
+
+      lastX = sample.points[0].x;
+      lastY = sample.points[0].y;
+
+      if (!longPressFired && sample.pointCount == 1 &&
+          (sample.timestamp - touchStartMs) > LONG_PRESS_MS) {
+        longPressFired = true;
+        event.type = LONG_PRESS;
+        return event;
+      }
+
+      if (sample.pointCount >= 2 && sample.points[0].valid && sample.points[1].valid) {
+        const float distanceNow = distanceBetween(sample.points[0], sample.points[1]);
+
+        if (!hasPinchStart) {
+          pinchStartDistance = distanceNow;
+          hasPinchStart = true;
+        } else if (sample.timestamp >= pinchCooldownUntil) {
+          const float delta = distanceNow - pinchStartDistance;
+          if (delta > PINCH_THRESHOLD) {
+            pinchCooldownUntil = sample.timestamp + PINCH_COOLDOWN_MS;
+            pinchStartDistance = distanceNow;
+            event.type = PINCH_OUT;
+            return event;
+          }
+          if (delta < -PINCH_THRESHOLD) {
+            pinchCooldownUntil = sample.timestamp + PINCH_COOLDOWN_MS;
+            pinchStartDistance = distanceNow;
+            event.type = PINCH_IN;
+            return event;
+          }
+        }
+      }
+
+      return event;
+    }
+
+    if (!sample.touched && isTouchDown) {
+      event.type = classifyReleaseGesture(sample);
+      resetTouchState();
+      return event;
+    }
+
+    return event;
+  }
+
+private:
+  static const uint16_t TAP_MAX_TRAVEL = 20;
+  static const uint16_t SWIPE_MIN_TRAVEL = 70;
+  static const uint16_t LONG_PRESS_MS = 900;
+  static constexpr float PINCH_THRESHOLD = 18.0f;
+  static const uint16_t PINCH_COOLDOWN_MS = 120;
+
+  bool isTouchDown;
+  uint32_t touchStartMs;
+  int16_t startX;
+  int16_t startY;
+  int16_t lastX;
+  int16_t lastY;
+  bool hasPinchStart;
+  float pinchStartDistance;
+  uint32_t pinchCooldownUntil;
+  bool longPressFired;
+
+  void beginTouch(const TouchSample& sample) {
+    isTouchDown = true;
+    touchStartMs = sample.timestamp;
+    startX = sample.points[0].x;
+    startY = sample.points[0].y;
+    lastX = startX;
+    lastY = startY;
+    hasPinchStart = false;
+    longPressFired = false;
+  }
+
+  void resetTouchState() {
+    isTouchDown = false;
+    hasPinchStart = false;
+    longPressFired = false;
+  }
+
+  GestureType classifyReleaseGesture(const TouchSample& sample) {
+    if (longPressFired) {
+      return NONE;
+    }
+
+    const int16_t dx = lastX - startX;
+    const int16_t dy = lastY - startY;
+    const uint16_t absDx = abs(dx);
+    const uint16_t absDy = abs(dy);
+
+    if (absDx <= TAP_MAX_TRAVEL && absDy <= TAP_MAX_TRAVEL) {
+      return TAP;
+    }
+
+    if (absDx >= SWIPE_MIN_TRAVEL || absDy >= SWIPE_MIN_TRAVEL) {
+      if (absDx > absDy) {
+        return dx > 0 ? SWIPE_RIGHT : SWIPE_LEFT;
+      }
+      return dy > 0 ? SWIPE_DOWN : SWIPE_UP;
+    }
+
+    return NONE;
+  }
+
+  float distanceBetween(const TouchPoint& a, const TouchPoint& b) {
+    const float dx = (float)a.x - (float)b.x;
+    const float dy = (float)a.y - (float)b.y;
+    return sqrtf((dx * dx) + (dy * dy));
+  }
+};
+
+#endif


### PR DESCRIPTION
### Motivation
- Provide high-level touch actions (tap, long-press, swipes, pinch) so screens can respond to gestures without each screen reimplementing touch state. 
- Introduce small, reusable UI primitives so screens can be composed from buttons, grids and tables instead of duplicated drawing/hit-testing code. 

### Description
- Added structured touch sampling and multi-touch support in `touch.h` (`TouchPoint`/`TouchSample`, `touch_read_sample()`) and mapping helpers so raw FT6336 data can be consumed by gesture logic. 
- Introduced `TouchGestureEngine` in `ui_touch.h` that classifies samples into `TAP`, `LONG_PRESS`, `SWIPE_*`, and `PINCH_IN`/`PINCH_OUT` events. 
- Implemented a lightweight UI library `ui_components.h` providing `UIButton`, `UIButtonGrid`, and `UITable` with hit-testing and sprite drawing to build menus and tables. 
- Refactored `options_screen.h` to use `UIButtonGrid`/`UIButton`/`UITable` and to be gesture-aware (swipe-back behavior and gesture-driven submenu navigation). 
- Integrated gesture handling into `ESP32OBDGauge.ino` (instantiated `TouchGestureEngine`, replaced manual touch-state code, added `switchToPreviousGauge()` and gesture-to-action mappings such as swipe navigation, pinch open/reset, long-press to options). 

### Testing
- Attempted an automated firmware compile using `arduino-cli` but the environment does not have `arduino-cli` installed so compilation could not be executed (compile attempt failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bb666ef483239cf3858c1d2f4a4f)