### PR TITLE
Improve touch navigation and simplify arc gauge selection UX

### DIFF
--- a/ESP32OBDGauge.ino
+++ b/ESP32OBDGauge.ino
@@ -27,8 +27,8 @@ bool gmeterCalibrationStored = false;
 
 Preferences preferences;
 TFT_eSPI display = TFT_eSPI();
-const int GAUGE_COUNT = 8;
-const int FALLBACK_GAUGE_INDEX = 5;
+const int GAUGE_COUNT = 5;
+const int FALLBACK_GAUGE_INDEX = 2;
 Gauge* gauges[GAUGE_COUNT];
 ScreenManager screenManager;
 Commands commands;
@@ -67,17 +67,14 @@ void setup() {
     }
 
     gaugeMutex = xSemaphoreCreateMutex();
-    gauges[0] = new NeedleGauge(&display, 0, outlineColor, needleColor, valueColor); // RPM    (Actual)
-    gauges[1] = new NeedleGauge(&display, 1, outlineColor, needleColor, valueColor); // Boost  (Approximate)
-    gauges[2] = new NeedleGauge(&display, 2, outlineColor, needleColor, valueColor); // Torque (Approximate)
-    gauges[3] = new NeedleGauge(&display, 3, outlineColor, needleColor, valueColor); // Horsepower (Approximate)
-    gauges[4] = new DualGauge(&display, 0, outlineColor, needleColor, valueColor);
-    gauges[5] = new GMeter(&display);
-    gauges[6] = new AccelerationMeter(&display);
-    gauges[7] = new QuadrantGauge(&display, &commands);
+    gauges[0] = new NeedleGauge(&display, 0, outlineColor, needleColor, valueColor); // Configurable: RPM/Boost/Torque/Power
+    gauges[1] = new DualGauge(&display, 0, outlineColor, needleColor, valueColor);
+    gauges[2] = new GMeter(&display);
+    gauges[3] = new AccelerationMeter(&display);
+    gauges[4] = new QuadrantGauge(&display, &commands);
 
     if (gmeterCalibrationStored) {
-        static_cast<GMeter*>(gauges[5])->setStoredCalibration(mpuCalibrationMatrix, mpuCalibrationBias);
+        static_cast<GMeter*>(gauges[2])->setStoredCalibration(mpuCalibrationMatrix, mpuCalibrationBias);
     }
 
     if (!obdConnected) {
@@ -178,8 +175,8 @@ void dataFetchingTask(void* parameter) {
         switch (gauge->getType()) {
             case Gauge::NEEDLE_GAUGE:
                 if (obdConnected) {
-                    double reading = commands.getReading(gaugeIndex);
                     NeedleGauge* ng = static_cast<NeedleGauge*>(gauge);
+                    double reading = commands.getReading(ng->getGaugeTypeIndex());
                     ng->setReading(reading);
                     vTaskDelay(100 / portTICK_PERIOD_MS); // 10Hz
                 } else {
@@ -274,8 +271,20 @@ void loop() {
                 if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
                     QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
                     if (qg->isSelectorVisible()) {
-                        if (!waitingForReleaseAfterQuadrantSelector) {
+                        if (!touchHandledForCurrentPress) {
                             qg->handleTouch(touch_last_x, touch_last_y);
+                            touchHandledForCurrentPress = true;
+                            waitingForReleaseAfterQuadrantSelector = true;
+                        }
+                        handledSelectorTouch = true;
+                    }
+                } else if (current != nullptr && current->getType() == Gauge::NEEDLE_GAUGE) {
+                    NeedleGauge* ng = static_cast<NeedleGauge*>(current);
+                    if (ng->isTypeSelectorVisible()) {
+                        if (!touchHandledForCurrentPress) {
+                            ng->handleTypeSelectorTouch(touch_last_x, touch_last_y);
+                            touchHandledForCurrentPress = true;
+                            waitingForReleaseAfterQuadrantSelector = true;
                         }
                         handledSelectorTouch = true;
                     }
@@ -288,6 +297,10 @@ void loop() {
                     if (current != nullptr && current->getType() == Gauge::QUADRANT_GAUGE) {
                         QuadrantGauge* qg = static_cast<QuadrantGauge*>(current);
                         qg->openSelectorFromTouch(touch_last_x, touch_last_y);
+                        waitingForReleaseAfterQuadrantSelector = true;
+                    } else if (current != nullptr && current->getType() == Gauge::NEEDLE_GAUGE) {
+                        NeedleGauge* ng = static_cast<NeedleGauge*>(current);
+                        ng->openTypeSelector();
                         waitingForReleaseAfterQuadrantSelector = true;
                     } else {
                         showOptions();
@@ -331,6 +344,12 @@ void loop() {
                         qg->handleTouch(gesture.endX, gesture.endY);
                         handledByQuadrantSelector = true;
                     }
+                } else if (current != nullptr && current->getType() == Gauge::NEEDLE_GAUGE) {
+                    NeedleGauge* ng = static_cast<NeedleGauge*>(current);
+                    if (ng->isTypeSelectorVisible()) {
+                        ng->handleTypeSelectorTouch(gesture.endX, gesture.endY);
+                        handledByQuadrantSelector = true;
+                    }
                 }
                 xSemaphoreGive(gaugeMutex);
 
@@ -372,7 +391,7 @@ void loop() {
             current->render(0.0);
         }
 
-        GMeter* gm = static_cast<GMeter*>(gauges[5]);
+        GMeter* gm = static_cast<GMeter*>(gauges[2]);
         float savedRotation[3][3];
         Vec3 savedBias;
         if (gm->consumeCalibration(savedRotation, savedBias)) {
@@ -443,7 +462,7 @@ void exitOptions() {
 
     Gauge::GaugeType gaugeType = current->getType();
 
-    if (gaugeType != Gauge::ACCELERATION_METER && gaugeType != Gauge::G_METER) {
+    if (gaugeType == Gauge::NEEDLE_GAUGE || gaugeType == Gauge::DUAL_GAUGE) {
         // Store new preferences when exiting options screen only for needle and dual gauges
         uint32_t currNeedleColor = current->getCurrentNeedleColor();
         uint32_t currOutlineColor = current->getCurrentOutlineColor();

--- a/needle_gauge.h
+++ b/needle_gauge.h
@@ -2,6 +2,7 @@
 #define NEEDLE_GAUGE_H
 
 #include "gauge.h"
+#include "ui_library.h"
 
 class NeedleGauge : public Gauge {
 public:
@@ -18,6 +19,7 @@ public:
         minValue(gaugeTypes[gaugeType][2].toDouble()),
         maxValue(gaugeTypes[gaugeType][3].toDouble()),
         valueType(gaugeTypes[gaugeType][4]),
+        gaugeTypeIndex(gaugeType),
         targetValue(0.0),
         currentAngle(GAUGE_START_ANGLE),
         oldAngle(GAUGE_START_ANGLE),
@@ -55,6 +57,60 @@ public:
 
     void setReading(double reading) {
         targetValue = constrain(reading, minValue, maxValue);
+    }
+
+    void setGaugeType(int newGaugeType) {
+        if (newGaugeType < 0 || newGaugeType > 3 || newGaugeType == gaugeTypeIndex) {
+            return;
+        }
+
+        gaugeTypeIndex = newGaugeType;
+        valueLabel = gaugeTypes[gaugeTypeIndex][0];
+        valueUnits = gaugeTypes[gaugeTypeIndex][1];
+        minValue = gaugeTypes[gaugeTypeIndex][2].toDouble();
+        maxValue = gaugeTypes[gaugeTypeIndex][3].toDouble();
+        valueType = gaugeTypes[gaugeTypeIndex][4];
+        targetValue = minValue;
+        resetSweep();
+        initialize();
+    }
+
+    int getGaugeTypeIndex() const {
+        return gaugeTypeIndex;
+    }
+
+    void openTypeSelector() {
+        selectorOpen = true;
+        drawTypeSelector();
+    }
+
+    bool isTypeSelectorVisible() const {
+        return selectorOpen;
+    }
+
+    bool handleTypeSelectorTouch(uint16_t x, uint16_t y) {
+        if (!selectorOpen) {
+            return false;
+        }
+
+        UIButton buttons[4] = {
+            buildSelectorButton(0, 0, 0, "RPM"),
+            buildSelectorButton(1, 0, 1, "BOOST"),
+            buildSelectorButton(2, 1, 0, "TORQUE"),
+            buildSelectorButton(3, 1, 1, "POWER")
+        };
+
+        for (int i = 0; i < 4; i++) {
+            if (buttons[i].hitTest(x, y)) {
+                selectorOpen = false;
+                setGaugeType(buttons[i].getId());
+                return true;
+            }
+        }
+
+        selectorOpen = false;
+        initialize();
+        return true;
     }
 
     void setNeedleColor(uint16_t color) {
@@ -166,6 +222,8 @@ private:
     double minValue, maxValue;
     String valueLabel, valueUnits, valueType;
     uint16_t needleColor, outlineColor, valueColor;
+    int gaugeTypeIndex;
+    bool selectorOpen = false;
 
     // Sweep state
     enum SweepState { SWEEP_UP, SWEEP_DOWN, SWEEP_COMPLETE };
@@ -174,6 +232,47 @@ private:
     double sweepValue;
 
     static String gaugeTypes[4][5];
+
+    static const int SELECTOR_BUTTON_MARGIN = 10;
+    static const int SELECTOR_BUTTON_SPACING = 10;
+
+    UIButton buildSelectorButton(int id, int row, int col, const char* label) {
+        int buttonWidth = (DISPLAY_WIDTH - (SELECTOR_BUTTON_MARGIN * 2) - SELECTOR_BUTTON_SPACING) / 2;
+        int buttonHeight = (DISPLAY_HEIGHT - (SELECTOR_BUTTON_MARGIN * 2) - SELECTOR_BUTTON_SPACING) / 2;
+        UIRect rect = {
+            static_cast<int16_t>(SELECTOR_BUTTON_MARGIN + col * (buttonWidth + SELECTOR_BUTTON_SPACING)),
+            static_cast<int16_t>(SELECTOR_BUTTON_MARGIN + row * (buttonHeight + SELECTOR_BUTTON_SPACING)),
+            static_cast<int16_t>(buttonWidth),
+            static_cast<int16_t>(buttonHeight)
+        };
+        return UIButton(id, label, rect, TFT_DARKGREY, TFT_WHITE, TFT_WHITE);
+    }
+
+    void drawTypeSelector() {
+        display->fillScreen(TFT_BLACK);
+        const char* labels[4] = {"RPM", "BOOST", "TORQUE", "POWER"};
+        for (int i = 0; i < 4; i++) {
+            UIButton button = buildSelectorButton(i, i / 2, i % 2, labels[i]);
+            UIRect rect = button.getBounds();
+            display->fillRect(rect.x, rect.y, rect.w, rect.h, TFT_DARKGREY);
+            display->drawRect(rect.x, rect.y, rect.w, rect.h, TFT_WHITE);
+            display->setTextFont(2);
+            display->setTextSize(1);
+            display->setTextColor(TFT_WHITE, TFT_DARKGREY);
+            int textWidth = display->textWidth(labels[i]);
+            int textHeight = display->fontHeight();
+            display->setCursor(rect.x + (rect.w - textWidth) / 2, rect.y + (rect.h - textHeight) / 2);
+            display->print(labels[i]);
+        }
+    }
+
+    void resetSweep() {
+        sweepState = SWEEP_UP;
+        sweepStartTime = millis();
+        sweepValue = minValue;
+        currentAngle = GAUGE_START_ANGLE;
+        oldAngle = GAUGE_START_ANGLE;
+    }
 
     void createOutline() {
         if (!gaugeOutline.createSprite(GAUGE_WIDTH, GAUGE_HEIGHT)) {

--- a/options_screen.h
+++ b/options_screen.h
@@ -217,7 +217,7 @@ private:
 
     bool handleBluetoothTouch(uint16_t x, uint16_t y) {
         if (bluetoothState == BLUETOOTH_STATS) {
-            UIButton backButton(0, "Back", {65, 180, 190, 45});
+            UIButton backButton(0, "Back", {10, 205, 300, 30});
             if (backButton.hitTest(x, y)) {
                 bluetoothState = BLUETOOTH_MENU;
                 drawBluetoothMenu();
@@ -301,7 +301,7 @@ private:
         screenSprite.fillSprite(TFT_BLACK);
 
         UITable statsTable;
-        statsTable.configure({20, 20, 280, 140}, 4, 2);
+        statsTable.configure({5, 5, 310, 190}, 4, 2);
         statsTable.setCell(0, 0, "Metric");
         statsTable.setCell(0, 1, "Value");
         statsTable.setCell(1, 0, "Connected");
@@ -312,7 +312,7 @@ private:
         statsTable.setCell(3, 1, SOFTWARE_VERSION);
         statsTable.draw(screenSprite, true);
 
-        UIButton backButton(0, "Back", {65, 180, 190, 45});
+        UIButton backButton(0, "Back", {10, 205, 300, 30});
         backButton.draw(screenSprite, 2, 1);
         screenSprite.pushSprite(0, 0);
     }

--- a/quadrant_gauge.h
+++ b/quadrant_gauge.h
@@ -29,7 +29,7 @@ public:
             Serial.println("Failed to create QuadrantGauge screen sprite");
         }
 
-        if (!selector.createSprite(DISPLAY_WIDTH - 30, DISPLAY_HEIGHT - 30)) {
+        if (!selector.createSprite(DISPLAY_WIDTH, DISPLAY_HEIGHT)) {
             Serial.println("Failed to create QuadrantGauge selector sprite");
         }
 
@@ -83,25 +83,21 @@ public:
             return false;
         }
 
-        int localX = x - 15;
-        int localY = y - 15;
-        if (localX < 0 || localY < 0 || localX >= (DISPLAY_WIDTH - 30) || localY >= (DISPLAY_HEIGHT - 30)) {
-            selectorOpen = false;
-            return true;
-        }
+        int localX = x;
+        int localY = y;
 
-        const int rowHeight = 24;
-        const int top = 32;
-        const int visibleRows = 7;
+        const int rowHeight = 42;
+        const int top = 48;
+        const int visibleRows = 5;
 
-        int prevY = DISPLAY_HEIGHT - 65;
-        int nextY = DISPLAY_HEIGHT - 65;
-        if (localY >= prevY && localY < prevY + 22 && localX >= 10 && localX < 90) {
+        int prevY = DISPLAY_HEIGHT - 52;
+        int nextY = DISPLAY_HEIGHT - 52;
+        if (localY >= prevY && localY < prevY + 42 && localX >= 10 && localX < 145) {
             pageStart = max(0, pageStart - visibleRows);
             return true;
         }
 
-        if (localY >= nextY && localY < nextY + 22 && localX >= (DISPLAY_WIDTH - 30 - 90) && localX < (DISPLAY_WIDTH - 30 - 10)) {
+        if (localY >= nextY && localY < nextY + 42 && localX >= (DISPLAY_WIDTH - 145) && localX < (DISPLAY_WIDTH - 10)) {
             int maxStart = max(0, commands->getCommandCount() - visibleRows);
             pageStart = min(maxStart, pageStart + visibleRows);
             return true;
@@ -218,11 +214,11 @@ private:
         selector.setTextFont(1);
 
         String title = "Select value for quadrant " + String(selectedQuadrant + 1);
-        selector.drawString(title, 8, 8, 2);
+        selector.drawString(title, 8, 12, 2);
 
-        const int rowHeight = 24;
-        const int top = 32;
-        const int visibleRows = 7;
+        const int rowHeight = 42;
+        const int top = 48;
+        const int visibleRows = 5;
 
         for (int i = 0; i < visibleRows; i++) {
             int commandIndex = pageStart + i;
@@ -233,26 +229,26 @@ private:
             int rowY = top + i * rowHeight;
             bool active = (selectedCommands[selectedQuadrant] == commandIndex);
             uint16_t bg = active ? TFT_DARKGREEN : TFT_DARKGREY;
-            selector.fillRect(6, rowY, selector.width() - 12, rowHeight - 2, bg);
+            selector.fillRect(6, rowY, selector.width() - 12, rowHeight - 4, bg);
 
             String originalLabel = commands->getCommandLabel(commandIndex);
             String rowLabel = originalLabel;
-            while (rowLabel.length() > 0 && selector.textWidth(rowLabel, 2) > selector.width() - 24) {
+            while (rowLabel.length() > 0 && selector.textWidth(rowLabel, 2) > selector.width() - 28) {
                 rowLabel.remove(rowLabel.length() - 1);
             }
             if (rowLabel != originalLabel) {
                 rowLabel += "...";
             }
-            selector.drawString(rowLabel, 12, rowY + 6, 2);
+            selector.drawString(rowLabel, 12, rowY + 12, 2);
         }
 
-        selector.fillRect(10, selector.height() - 35, 80, 22, TFT_BLUE);
-        selector.drawString("Prev", 28, selector.height() - 30, 2);
+        selector.fillRect(10, selector.height() - 52, 135, 42, TFT_DARKGREY);
+        selector.drawString("Prev", 54, selector.height() - 40, 2);
 
-        selector.fillRect(selector.width() - 90, selector.height() - 35, 80, 22, TFT_BLUE);
-        selector.drawString("Next", selector.width() - 72, selector.height() - 30, 2);
+        selector.fillRect(selector.width() - 145, selector.height() - 52, 135, 42, TFT_DARKGREY);
+        selector.drawString("Next", selector.width() - 100, selector.height() - 40, 2);
 
-        selector.pushSprite(15, 15);
+        selector.pushSprite(0, 0);
     }
 };
 


### PR DESCRIPTION
### Motivation
- Make the options UI easier to tap by using more of the screen and larger hit targets and fix selector navigation which was skipping multiple pages when a touch was held. 
- Replace the many small arc gauges with a single configurable main needle gauge that can be long-pressed to choose one of the four primary gauges (RPM, BOOST, TORQUE, POWER) using the existing grey-button options style.

### Description
- Enlarged the Bluetooth stats table and widened the Back button hit area in `options_screen.h` so the table occupies nearly the full display and controls are easier to press. 
- Reworked the quadrant selector in `quadrant_gauge.h` to create a full-screen selector sprite, use larger row heights and larger Prev / Next grey buttons, and adjusted layout/push coordinates for accurate rendering. 
- Consolidated arc gauges into a single configurable `NeedleGauge` in `needle_gauge.h` by adding `gaugeTypeIndex`, a 2x2 grey `drawTypeSelector()` UI, and public methods `openTypeSelector()`, `handleTypeSelectorTouch()`, `setGaugeType()`, and `getGaugeTypeIndex()`. 
- Updated app flow and gauge list in `ESP32OBDGauge.ino` to use a smaller `GAUGE_COUNT` (single configurable needle gauge + dual + GMeter + Accel + Quadrant), to open the needle-type selector on long-press, and to use a one-shot touch handling state (`touchHandledForCurrentPress` / `waitingForReleaseAfterQuadrantSelector`) to prevent repeated Next/Prev advances while the screen is held. 
- Adjusted data fetching so the needle gauge reads the currently-selected metric via `NeedleGauge::getGaugeTypeIndex()` and updated options exit logic to only persist color settings for needle/dual gauges.

### Testing
- Attempted to build the firmware with `arduino-cli compile --fqbn esp32:esp32:esp32 ESP32OBDGauge.ino`, but the compile could not run because `arduino-cli` is not installed in this environment. 
- Ran repository verification commands (`git status`, `git diff`) and applied/inspected the changes; the patch was committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa495d6d808323a49e2633585dbb55)