### PR TITLE
Fix acceleration meter finish logic and quadrant selector layout

### DIFF
--- a/acceleration_meter.h
+++ b/acceleration_meter.h
@@ -106,10 +106,12 @@ public:
             case RUNNING:
                 runTimeSeconds = (double)(nowUs - startTimeUs) / 1000000.0;
 
-                if (previousSpeed < 60.0 && latestSpeed >= 60.0 && latestSpeed > previousSpeed) {
-                    double fraction = (60.0 - previousSpeed) / (latestSpeed - previousSpeed);
-                    unsigned long long crossedUs = previousTimeUs + (unsigned long long)(fraction * (double)(nowUs - previousTimeUs));
-                    runTimeSeconds = (double)(crossedUs - startTimeUs) / 1000000.0;
+                if (latestSpeed >= 60.0) {
+                    if (latestSpeed > previousSpeed && previousSpeed < 60.0) {
+                        double fraction = (60.0 - previousSpeed) / (latestSpeed - previousSpeed);
+                        unsigned long long crossedUs = previousTimeUs + (unsigned long long)(fraction * (double)(nowUs - previousTimeUs));
+                        runTimeSeconds = (double)(crossedUs - startTimeUs) / 1000000.0;
+                    }
                     stage = FINISHED;
                     drawTime(runTimeSeconds, TFT_GREEN);
                     drawMessageForStage();

--- a/quadrant_gauge.h
+++ b/quadrant_gauge.h
@@ -86,18 +86,17 @@ public:
         int localX = x;
         int localY = y;
 
-        const int rowHeight = 42;
-        const int top = 48;
-        const int visibleRows = 5;
+        const int rowHeight = 36;
+        const int top = 8;
+        const int bottomButtonY = DISPLAY_HEIGHT - 44;
+        const int visibleRows = (bottomButtonY - top) / rowHeight;
 
-        int prevY = DISPLAY_HEIGHT - 52;
-        int nextY = DISPLAY_HEIGHT - 52;
-        if (localY >= prevY && localY < prevY + 42 && localX >= 10 && localX < 145) {
+        if (localY >= bottomButtonY && localY < bottomButtonY + 34 && localX >= 10 && localX < 145) {
             pageStart = max(0, pageStart - visibleRows);
             return true;
         }
 
-        if (localY >= nextY && localY < nextY + 42 && localX >= (DISPLAY_WIDTH - 145) && localX < (DISPLAY_WIDTH - 10)) {
+        if (localY >= bottomButtonY && localY < bottomButtonY + 34 && localX >= (DISPLAY_WIDTH - 145) && localX < (DISPLAY_WIDTH - 10)) {
             int maxStart = max(0, commands->getCommandCount() - visibleRows);
             pageStart = min(maxStart, pageStart + visibleRows);
             return true;
@@ -213,12 +212,10 @@ private:
         selector.setTextColor(TFT_WHITE, TFT_BLACK);
         selector.setTextFont(1);
 
-        String title = "Select value for quadrant " + String(selectedQuadrant + 1);
-        selector.drawString(title, 8, 12, 2);
-
-        const int rowHeight = 42;
-        const int top = 48;
-        const int visibleRows = 5;
+        const int rowHeight = 36;
+        const int top = 8;
+        const int bottomButtonY = selector.height() - 44;
+        const int visibleRows = (bottomButtonY - top) / rowHeight;
 
         for (int i = 0; i < visibleRows; i++) {
             int commandIndex = pageStart + i;
@@ -229,7 +226,8 @@ private:
             int rowY = top + i * rowHeight;
             bool active = (selectedCommands[selectedQuadrant] == commandIndex);
             uint16_t bg = active ? TFT_DARKGREEN : TFT_DARKGREY;
-            selector.fillRect(6, rowY, selector.width() - 12, rowHeight - 4, bg);
+            selector.fillRect(6, rowY, selector.width() - 12, rowHeight - 3, bg);
+            selector.drawRect(6, rowY, selector.width() - 12, rowHeight - 3, TFT_WHITE);
 
             String originalLabel = commands->getCommandLabel(commandIndex);
             String rowLabel = originalLabel;
@@ -239,14 +237,16 @@ private:
             if (rowLabel != originalLabel) {
                 rowLabel += "...";
             }
-            selector.drawString(rowLabel, 12, rowY + 12, 2);
+            selector.drawString(rowLabel, 12, rowY + 9, 2);
         }
 
-        selector.fillRect(10, selector.height() - 52, 135, 42, TFT_DARKGREY);
-        selector.drawString("Prev", 54, selector.height() - 40, 2);
+        selector.fillRect(10, bottomButtonY, 135, 34, TFT_DARKGREY);
+        selector.drawRect(10, bottomButtonY, 135, 34, TFT_WHITE);
+        selector.drawString("Prev", 54, bottomButtonY + 10, 2);
 
-        selector.fillRect(selector.width() - 145, selector.height() - 52, 135, 42, TFT_DARKGREY);
-        selector.drawString("Next", selector.width() - 100, selector.height() - 40, 2);
+        selector.fillRect(selector.width() - 145, bottomButtonY, 135, 34, TFT_DARKGREY);
+        selector.drawRect(selector.width() - 145, bottomButtonY, 135, 34, TFT_WHITE);
+        selector.drawString("Next", selector.width() - 100, bottomButtonY + 10, 2);
 
         selector.pushSprite(0, 0);
     }


### PR DESCRIPTION
### Motivation

- Ensure the 0–60 acceleration run transitions to a latched `FINISHED` state and displays the final time when the speed threshold is reached. 
- Prevent the quadrant selector’s `Prev`/`Next` buttons from overlapping selectable rows and improve touch target clarity by adding visible boundaries.

### Description

- In `acceleration_meter.h` updated the `RUNNING` state to set `stage = FINISHED` when `latestSpeed >= 60.0` and preserve the interpolated crossing-time calculation only when the sample actually crossed from below 60 (`previousSpeed < 60.0`).
- In `quadrant_gauge.h` removed the title row from the selector, reduced row height, computed `bottomButtonY` and `visibleRows` dynamically so the list area and navigation buttons do not overlap, and adjusted row text positioning.
- Added visible borders by drawing rectangles around each selector row and the `Prev`/`Next` buttons and updated hit-test bounds to match the new bottom button area.
- Changes touch handling and drawing exclusively in `acceleration_meter.h` and `quadrant_gauge.h` to implement the above behavior and UI improvements.

### Testing

- Applied the patch and programmatic edits successfully with the repository updates completing without errors (patch and Python modifications succeeded).
- Ran `git diff` to inspect the produced diffs for `acceleration_meter.h` and `quadrant_gauge.h`, and verified the intended lines were changed successfully.
- Verified repository state with `git status` and `git log -1 --oneline` to confirm the commit was created; these checks succeeded.
- Reviewed the modified logic and selector geometry via static inspection to confirm the `FINISHED` transition and non-overlapping button/row layout were implemented as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf470a3c08323a49e876939a0990f)